### PR TITLE
feat: add workflow to build docker container and trigger deployment to aws nonprod envs

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -77,7 +77,7 @@ jobs:
           git checkout -b "auto/bump-${{ inputs.service_name }}-to-${{ env.IMAGE_TAG }}"
 
           filename="cloud/aws/fc-services-dev/use1/primary/${{ inputs.team_name }}/applications/${{ inputs.service_name }}/values.yaml"
-          yq  -i eval '.fc-service.process.tag = "${{ env.IMAGE_TAG }}"' ${filename}
+          yq  -i eval '.fc-service.process.tag = ${{ env.IMAGE_TAG }}' ${filename}
 
           git diff
           git add ${filename}

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -32,9 +32,6 @@ jobs:
       IMAGE_TAG: ${{ github.run_number }}
     steps:
       -
-        name: "Check IMAGE_TAG"
-        run: "echo ${{ env.IMAGE_TAG }}"
-      -
         name: Set up Docker Context for Buildx
         id: buildx-context
         run: |
@@ -58,6 +55,7 @@ jobs:
         with:
           push: true
           github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+          # TODO: these cache settings don't seem to be doing much...
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
@@ -71,20 +69,24 @@ jobs:
       -
         name: Update the image tags in values.yaml and push commit
         run: |
-          echo "\n\nInstalling yq..."
+          echo; echo;
+          echo "Installing yq..."
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod a+x /usr/local/bin/yq
 
-          echo "\n\nSetting git config..."
+          echo; echo;
+          echo "Setting git config..."
           git config --local user.name ${{ github.event.pusher.name }}
           git config --local user.email ${{ github.event.pusher.email }}
 
-          echo "\n\nUpdating values.yaml..."
+          echo; echo;
+          echo "Updating values.yaml..."
           filename="cloud/aws/fc-services-dev/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
           yq  -i eval '.fc-service.process.tag = ${{ env.IMAGE_TAG }}' ${filename}
           git diff
 
-          echo "\n\nPushing to git..."
+          echo; echo;
+          echo "Pushing to git..."
           git add ${filename}
           git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}"
           git push origin HEAD

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -69,11 +69,11 @@ jobs:
           repository: dtx-company/sample-infra-kubernetes
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
       -
-        name: Install yq
-        uses: chrisdickinson/setup-yq@latest
-      -
-        name: Update the image tag in fc-services-dev and push a branch
+        name: Update the image tag in fc-services-dev and create a PR
         run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod a+x /usr/local/bin/yq
+
           git config --local user.name ${{ github.event.pusher.name }}
           git config --local user.email ${{ github.event.pusher.email }}
           git checkout -b "auto/bump-${{ inputs.service }}-to-${{ env.IMAGE_TAG }}"

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -3,7 +3,10 @@ name: build-and-push-and-nonprod-release
 on:
   workflow_call:
     inputs:
-      service_name:
+      service_name:      # Example: "ithaca"
+        required: true
+        type: string
+      team_name:         # Example: "revenue"
         required: true
         type: string
 
@@ -39,7 +42,7 @@ jobs:
         with:
           push: true
           tags: |
-            ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/flowcode-generator-server:${{ github.run_number }}
+            ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service_name }}:${{ github.run_number }}
       -
         name: Checkout sample-infra-kubernetes repo
         uses: actions/checkout@v2
@@ -54,14 +57,14 @@ jobs:
 
           git config --local user.name ${{ github.event.pusher.name }}
           git config --local user.email ${{ github.event.pusher.email }}
-          git checkout -b "auto/bump-flowcode-generator-server-to-${{ github.run_number }}"
+          git checkout -b "auto/bump-${{ inputs.service_name }}-to-${{ github.run_number }}"
 
-          filename="cloud/aws/fc-services-dev/use1/primary/backend/applications/flowcode-generator-server/values.yaml"
+          filename="cloud/aws/fc-services-dev/use1/primary/${{ inputs.team_name }}/applications/${{ inputs.service_name }}/values.yaml"
           yq  -i eval '.fc-service.process.tag = "${{ github.run_number }}"' ${filename}
 
           git diff
           git add ${filename}
-          git commit -m "auto: bump flowcode-generator-server to ${{ github.run_number }} for fc-services-dev"
+          git commit -m "auto: bump ${{ inputs.service_name }} to ${{ github.run_number }} for fc-services-dev"
           git show-ref
           git push origin HEAD
           git request-pull origin/trunk ./

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -12,19 +12,14 @@ on:
     secrets:
       JFROG_FLOWCODE_SERVER_NAME:
         required: true
-        type: string
       JFROG_FLOWCODE_FC_DOCKER_USERNAME:
         required: true
-        type: string
       JFROG_FLOWCODE_FC_DOCKER_PASSWORD:
         required: true
-        type: string
       JFROG_FLOWCODE_FC_DOCKER_REPO:
         required: true
-        type: string
       PERSONAL_ACCESS_TOKEN_REPO:
         required: true
-        type: string
 
 permissions:
       id-token: write    # Required for aws role assumption

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -52,6 +52,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_REPO }}
           tags: |
             ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service_name }}:${{ github.run_number }}
       -

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -63,29 +63,28 @@ jobs:
           tags: |
             ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service }}:${{ env.IMAGE_TAG }}
       -
-        name: Checkout sample-infra-kubernetes repo
+        name: Checkout kubernetes infra repo
         uses: actions/checkout@v2
         with:
           repository: dtx-company/sample-infra-kubernetes
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
       -
-        name: Update the image tag in fc-services-dev and create a PR
+        name: Update the image tags in values.yaml and push commit
         run: |
+          echo "\n\nInstalling yq..."
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod a+x /usr/local/bin/yq
 
+          echo "\n\nSetting git config..."
           git config --local user.name ${{ github.event.pusher.name }}
           git config --local user.email ${{ github.event.pusher.email }}
-          git checkout -b "auto/bump-${{ inputs.service }}-to-${{ env.IMAGE_TAG }}"
 
+          echo "\n\nUpdating values.yaml..."
           filename="cloud/aws/fc-services-dev/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
           yq  -i eval '.fc-service.process.tag = ${{ env.IMAGE_TAG }}' ${filename}
-
           git diff
+
+          echo "\n\nPushing to git..."
           git add ${filename}
           git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}"
-          git show-ref
           git push origin HEAD
-          git request-pull origin/trunk ./
-
-

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -33,7 +33,7 @@ jobs:
     steps:
       -
         name: "Check IMAGE_TAG"
-        run: "echo $IMAGE_TAG"
+        run: "echo ${{ env.IMAGE_TAG }}"
       -
         name: Set up Docker Context for Buildx
         id: buildx-context
@@ -59,7 +59,7 @@ jobs:
           push: true
           github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
           tags: |
-            ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service_name }}:$IMAGE_TAG
+            ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service_name }}:${{ env.IMAGE_TAG }}
       -
         name: Checkout sample-infra-kubernetes repo
         uses: actions/checkout@v2
@@ -74,14 +74,14 @@ jobs:
         run: |
           git config --local user.name ${{ github.event.pusher.name }}
           git config --local user.email ${{ github.event.pusher.email }}
-          git checkout -b "auto/bump-${{ inputs.service_name }}-to-$IMAGE_TAG"
+          git checkout -b "auto/bump-${{ inputs.service_name }}-to-${{ env.IMAGE_TAG }}"
 
           filename="cloud/aws/fc-services-dev/use1/primary/${{ inputs.team_name }}/applications/${{ inputs.service_name }}/values.yaml"
-          yq  -i eval '.fc-service.process.tag = "$IMAGE_TAG"' ${filename}
+          yq  -i eval '.fc-service.process.tag = "${{ env.IMAGE_TAG }}"' ${filename}
 
           git diff
           git add ${filename}
-          git commit -m "cicd-auto: nonprod bump ${{ inputs.service_name }} to $IMAGE_TAG"
+          git commit -m "cicd-auto: nonprod bump ${{ inputs.service_name }} to ${{ env.IMAGE_TAG }}"
           git show-ref
           git push origin HEAD
           git request-pull origin/trunk ./

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -9,6 +9,22 @@ on:
       team_name:         # Example: "revenue"
         required: true
         type: string
+    secrets:
+      JFROG_FLOWCODE_SERVER_NAME:
+        required: true
+        type: string
+      JFROG_FLOWCODE_FC_DOCKER_USERNAME:
+        required: true
+        type: string
+      JFROG_FLOWCODE_FC_DOCKER_PASSWORD:
+        required: true
+        type: string
+      JFROG_FLOWCODE_FC_DOCKER_REPO:
+        required: true
+        type: string
+      PERSONAL_ACCESS_TOKEN_REPO:
+        required: true
+        type: string
 
 permissions:
       id-token: write    # Required for aws role assumption

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -28,7 +28,12 @@ permissions:
 jobs:
   cd:
     runs-on: self-hosted
+    env:
+      IMAGE_TAG: ${{ github.run_number }}
     steps:
+      -
+        name: "Check IMAGE_TAG"
+        run: "echo $IMAGE_TAG"
       -
         name: Set up Docker Context for Buildx
         id: buildx-context
@@ -54,7 +59,7 @@ jobs:
           push: true
           github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
           tags: |
-            ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service_name }}:${{ github.run_number }}
+            ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service_name }}:$IMAGE_TAG
       -
         name: Checkout sample-infra-kubernetes repo
         uses: actions/checkout@v2
@@ -69,14 +74,14 @@ jobs:
         run: |
           git config --local user.name ${{ github.event.pusher.name }}
           git config --local user.email ${{ github.event.pusher.email }}
-          git checkout -b "auto/bump-${{ inputs.service_name }}-to-${{ github.run_number }}"
+          git checkout -b "auto/bump-${{ inputs.service_name }}-to-$IMAGE_TAG"
 
           filename="cloud/aws/fc-services-dev/use1/primary/${{ inputs.team_name }}/applications/${{ inputs.service_name }}/values.yaml"
-          yq  -i eval '.fc-service.process.tag = "${{ github.run_number }}"' ${filename}
+          yq  -i eval '.fc-service.process.tag = "$IMAGE_TAG"' ${filename}
 
           git diff
           git add ${filename}
-          git commit -m "auto: bump ${{ inputs.service_name }} to ${{ github.run_number }} for fc-services-dev"
+          git commit -m "cicd-auto: nonprod bump ${{ inputs.service_name }} to $IMAGE_TAG"
           git show-ref
           git push origin HEAD
           git request-pull origin/trunk ./

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -3,10 +3,10 @@ name: build-and-push-and-nonprod-release
 on:
   workflow_call:
     inputs:
-      service_name:      # Example: "ithaca"
+      service:
         required: true
         type: string
-      team_name:         # Example: "revenue"
+      project:
         required: true
         type: string
     secrets:
@@ -59,7 +59,7 @@ jobs:
           push: true
           github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
           tags: |
-            ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service_name }}:${{ env.IMAGE_TAG }}
+            ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service }}:${{ env.IMAGE_TAG }}
       -
         name: Checkout sample-infra-kubernetes repo
         uses: actions/checkout@v2
@@ -74,14 +74,14 @@ jobs:
         run: |
           git config --local user.name ${{ github.event.pusher.name }}
           git config --local user.email ${{ github.event.pusher.email }}
-          git checkout -b "auto/bump-${{ inputs.service_name }}-to-${{ env.IMAGE_TAG }}"
+          git checkout -b "auto/bump-${{ inputs.service }}-to-${{ env.IMAGE_TAG }}"
 
-          filename="cloud/aws/fc-services-dev/use1/primary/${{ inputs.team_name }}/applications/${{ inputs.service_name }}/values.yaml"
+          filename="cloud/aws/fc-services-dev/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
           yq  -i eval '.fc-service.process.tag = ${{ env.IMAGE_TAG }}' ${filename}
 
           git diff
           git add ${filename}
-          git commit -m "cicd-auto: nonprod bump ${{ inputs.service_name }} to ${{ env.IMAGE_TAG }}"
+          git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}"
           git show-ref
           git push origin HEAD
           git request-pull origin/trunk ./

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -18,7 +18,7 @@ on:
         required: true
       JFROG_FLOWCODE_FC_DOCKER_REPO:
         required: true
-      PERSONAL_ACCESS_TOKEN_REPO:
+      PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
         required: true
 
 permissions:
@@ -52,7 +52,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_REPO }}
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
           tags: |
             ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service_name }}:${{ github.run_number }}
       -
@@ -60,13 +60,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: dtx-company/sample-infra-kubernetes
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_REPO }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+      -
+        name: Install yq
+        uses: chrisdickinson/setup-yq@latest
       -
         name: Update the image tag in fc-services-dev and push a branch
         run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod a+x /usr/local/bin/yq
-
           git config --local user.name ${{ github.event.pusher.name }}
           git config --local user.email ${{ github.event.pusher.email }}
           git checkout -b "auto/bump-${{ inputs.service_name }}-to-${{ github.run_number }}"

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -58,6 +58,8 @@ jobs:
         with:
           push: true
           github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service }}:${{ env.IMAGE_TAG }}
       -

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,4 +1,4 @@
-name: build-and-push
+name: build-and-push-and-nonprod-release
 
 on:
   workflow_call:
@@ -9,10 +9,10 @@ on:
 
 permissions:
       id-token: write    # Required for aws role assumption
-      contents: write    # This is required for actions/checkout@v2
+      contents: write    # This is required for actions/checkout@v1
 
 jobs:
-  docker:
+  cd:
     runs-on: self-hosted
     steps:
       -
@@ -39,20 +39,31 @@ jobs:
         with:
           push: true
           tags: |
-            ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service_name }}:${{ github.run_number }}
-
-  deploy:
-    runs-on: self-hosted
-    steps:
+            ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/flowcode-generator-server:${{ github.run_number }}
       -
         name: Checkout sample-infra-kubernetes repo
         uses: actions/checkout@v2
         with:
           repository: dtx-company/sample-infra-kubernetes
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_REPO }}
       -
-        name: Update image tag
+        name: Update the image tag in fc-services-dev and push a branch
         run: |
-          git config --local user.email
-          git config --local user.name
-          git commit -m "auto: bump ${{ inputs.service-name }} to ${{ github.run_number }} for fc-services-dev, fc-services-stg, fc-services-preprod"
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod a+x /usr/local/bin/yq
+
+          git config --local user.name ${{ github.event.pusher.name }}
+          git config --local user.email ${{ github.event.pusher.email }}
+          git checkout -b "auto/bump-flowcode-generator-server-to-${{ github.run_number }}"
+
+          filename="cloud/aws/fc-services-dev/use1/primary/backend/applications/flowcode-generator-server/values.yaml"
+          yq  -i eval '.fc-service.process.tag = "${{ github.run_number }}"' ${filename}
+
+          git diff
+          git add ${filename}
+          git commit -m "auto: bump flowcode-generator-server to ${{ github.run_number }} for fc-services-dev"
+          git show-ref
+          git push origin HEAD
+          git request-pull origin/trunk ./
+
 

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,16 +1,19 @@
 name: build-and-push
 
 on:
-  push:
-    branches:
-      - 'jst/gh-actions'
+  workflow_call:
+    inputs:
+      service_name:
+        required: true
+        type: string
+
 permissions:
       id-token: write    # Required for aws role assumption
       contents: write    # This is required for actions/checkout@v1
+
 jobs:
   docker:
-    runs-on: ubuntu-latest
-    #runs-on: self-hosted
+    runs-on: self-hosted
     steps:
       -
         name: Set up Docker Context for Buildx
@@ -36,4 +39,4 @@ jobs:
         with:
           push: true
           tags: |
-            ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/flowcode-generator-server:${{ github.run_number }}
+            ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service_name }}:${{ github.run_number }}

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -9,7 +9,7 @@ on:
 
 permissions:
       id-token: write    # Required for aws role assumption
-      contents: write    # This is required for actions/checkout@v1
+      contents: write    # This is required for actions/checkout@v2
 
 jobs:
   docker:
@@ -40,3 +40,19 @@ jobs:
           push: true
           tags: |
             ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service_name }}:${{ github.run_number }}
+
+  deploy:
+    runs-on: self-hosted
+    steps:
+      -
+        name: Checkout sample-infra-kubernetes repo
+        uses: actions/checkout@v2
+        with:
+          repository: dtx-company/sample-infra-kubernetes
+      -
+        name: Update image tag
+        run: |
+          git config --local user.email
+          git config --local user.name
+          git commit -m "auto: bump ${{ inputs.service-name }} to ${{ github.run_number }} for fc-services-dev, fc-services-stg, fc-services-preprod"
+

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,0 +1,39 @@
+name: build-and-push
+
+on:
+  push:
+    branches:
+      - 'jst/gh-actions'
+permissions:
+      id-token: write    # Required for aws role assumption
+      contents: write    # This is required for actions/checkout@v1
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    #runs-on: self-hosted
+    steps:
+      -
+        name: Set up Docker Context for Buildx
+        id: buildx-context
+        run: |
+          docker context create builders
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          endpoint: builders
+      -
+        name: Login to Artifactory
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}
+          username: ${{ secrets.JFROG_FLOWCODE_FC_DOCKER_USERNAME }}
+          password: ${{ secrets.JFROG_FLOWCODE_FC_DOCKER_PASSWORD }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/flowcode-generator-server:${{ github.run_number }}


### PR DESCRIPTION
This workflow:
* builds and pushes a docker image to JFrog
* pushes a commit to trunk branch of the deployment repo; the commit bumps the image tag to the latest

Used flowcode-generator-server as the first example: https://github.com/dtx-company/flowcode-generator-server/pull/40

Fast follow ups:
* Need a tagging strategy for the shared workflows so that the calling workflows can pin to a version.
* Tuning the custom runners. James said they haven't been tuned at all yet.
* Add fc-services-stg and fc-services-preprod. Can do this after the deployment repo structure is set up.

Open questions/issues:
* We are using the github actions `run_number` as the image tag.  I believe this resets for each workflow, so if we change the workflow name that would start the numbers over from 1 again, which would either fail or overwrite what's already in JFrog.
* Caching -- the flowcode-generator-server build takes around 20 minutes each time :O Investigate the docker build push action that we are using. I tried some cache settings but it didn't help.

FYI:
* Reusable workflows don't appear to have access to org secrets or repo secrets directly; secrets need to be passed in as inputs from the calling workflow. This can be annoying because if we need a new secret, then we have to make the change everywhere.
