### PR TITLE
chore: remove TODO because cache is actually working

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -55,7 +55,6 @@ jobs:
         with:
           push: true
           github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
-          # TODO: these cache settings don't seem to be doing much...
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |


### PR DESCRIPTION
The latest run in flowcode-generator-server (https://github.com/dtx-company/flowcode-generator-server/pull/41) actually did use the cache which reduced the docker/build-and-push action from ~20min to 8s.