### PR TITLE
feat: update image tag in stg and preprod for nonprod release

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -80,12 +80,16 @@ jobs:
 
           echo; echo;
           echo "Updating values.yaml..."
-          filename="cloud/aws/fc-services-dev/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
-          yq  -i eval '.fc-service.process.tag = ${{ env.IMAGE_TAG }}' ${filename}
-          git diff
+          awsenvs=( "dev" "stg" "preprod" )
+          for awsenv in "${awsenvs[@]}"
+          do
+            filename="cloud/aws/fc-services-${awsenv}/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
+            yq -i eval '.fc-service.process.tag = ${{ env.IMAGE_TAG }}' ${filename}
+            git add ${filename}
+          done
 
           echo; echo;
           echo "Pushing to git..."
-          git add ${filename}
+          git diff HEAD
           git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}"
           git push origin HEAD


### PR DESCRIPTION
We used to only have fc-services-dev set up in fc-infra-kubernetes. Now we also have fc-services-stg and fc-services-preprod, and the nonprod release should update both of those too.