### PR TITLE
feat: gracefully handle case where image doesn't change, and include SHA of the source commit

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -68,7 +68,6 @@ jobs:
       -
         name: Update the image tags in values.yaml and push commit
         run: |
-          echo; echo;
           echo "Installing yq..."
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod a+x /usr/local/bin/yq
@@ -90,6 +89,9 @@ jobs:
 
           echo; echo;
           echo "Pushing to git..."
-          git diff HEAD
-          git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}"
-          git push origin HEAD
+          if [[ $(git diff HEAD) ]]; then
+            git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}"
+            git push origin HEAD
+          else
+            echo "Nothing to push"
+          fi

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -90,7 +90,7 @@ jobs:
           echo; echo;
           echo "Pushing to git..."
           if [[ $(git diff HEAD) ]]; then
-            git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}"
+            git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}" -m "triggered from ${{ github.sha }}"
             git push origin HEAD
           else
             echo "Nothing to push"


### PR DESCRIPTION
If a change is pushed in the source repository that doesn't result in a new image tag, then the shared workflow should handle that gracefully instead of erroring out with an empty commit. One example of such a change is updating the README.

Separately, I thought it would be nice if the commit that is autogenerated in fc-infra-kubernetes includes a link back to the original commit in the service repository that triggered that autogenerated version bump.