### PR TITLE
feat: add conventional-pr-title workflow wrapping an existing action from marketplace

### DIFF
--- a/.github/workflows/conventional-pr-title.yaml
+++ b/.github/workflows/conventional-pr-title.yaml
@@ -1,0 +1,15 @@
+name: conventional-pr-title
+
+on:
+  workflow_call:
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        with:
+          # Configuration docs: https://github.com/marketplace/actions/semantic-pull-request#configuration
+          validateSingleCommit: true
+          validateSingleCommitMatchesPrTitle: true

--- a/.github/workflows/conventional-pr-title.yaml
+++ b/.github/workflows/conventional-pr-title.yaml
@@ -2,12 +2,6 @@ name: conventional-pr-title
 
 on:
   workflow_call:
-    secrets:
-      # Reusable workflows must have secrets passed explicitly in.
-      # GITHUB_TOKEN is available automatically to the calling workflow.
-      #   See https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/#:~:text=GitHub%20Actions%20now%20lets%20you,token%20when%20a%20job%20completes.
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   validate:
@@ -20,4 +14,6 @@ jobs:
           validateSingleCommit: true
           validateSingleCommitMatchesPrTitle: true
         env:
+          # GITHUB_TOKEN is available automatically.
+          # See https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/#:~:text=GitHub%20Actions%20now%20lets%20you,token%20when%20a%20job%20completes.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conventional-pr-title.yaml
+++ b/.github/workflows/conventional-pr-title.yaml
@@ -2,10 +2,16 @@ name: conventional-pr-title
 
 on:
   workflow_call:
+    secrets:
+    # Reusable workflows must have secrets passed explicitly in.
+    # GITHUB_TOKEN is available automatically to the calling workflow.
+    #   See https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/#:~:text=GitHub%20Actions%20now%20lets%20you,token%20when%20a%20job%20completes.
+    GITHUB_TOKEN:
+      required: true
 
 jobs:
   validate:
-    name: Validate PR title
+    name: validate-pr-title
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v4
@@ -13,3 +19,5 @@ jobs:
           # Configuration docs: https://github.com/marketplace/actions/semantic-pull-request#configuration
           validateSingleCommit: true
           validateSingleCommitMatchesPrTitle: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conventional-pr-title.yaml
+++ b/.github/workflows/conventional-pr-title.yaml
@@ -3,11 +3,11 @@ name: conventional-pr-title
 on:
   workflow_call:
     secrets:
-    # Reusable workflows must have secrets passed explicitly in.
-    # GITHUB_TOKEN is available automatically to the calling workflow.
-    #   See https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/#:~:text=GitHub%20Actions%20now%20lets%20you,token%20when%20a%20job%20completes.
-    GITHUB_TOKEN:
-      required: true
+      # Reusable workflows must have secrets passed explicitly in.
+      # GITHUB_TOKEN is available automatically to the calling workflow.
+      #   See https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/#:~:text=GitHub%20Actions%20now%20lets%20you,token%20when%20a%20job%20completes.
+      GITHUB_TOKEN:
+        required: true
 
 jobs:
   validate:


### PR DESCRIPTION
This shared workflow is a thin wrapper around an existing action in marketplace called [semantic-pull-request](https://github.com/marketplace/actions/semantic-pull-request).

Behavior tested on screenshot-service (PR: https://github.com/dtx-company/screenshot-service/pull/39)

* workflow check succeeds if PR title conforms to conventional commits
* workflow check fails if PR title does not conform
* [including the "edited" action](https://github.com/dtx-company/screenshot-service/pull/39/files#diff-456be0857519f7fab1185cb557e9762d5277111df1ef99700f09c2da61ebeb5fR8) will cause the workflow to rerun when the PR title is changed
* edge case of single commit in the PR is handled by enforcing that commit message and PR title match and both follow conventional commit -- https://github.com/dtx-company/screenshot-service/pull/40

The action is configurable if we want to lock down which "types" of conventional commits are allowed, or if we want to enforce some regex on the subject of the commit, but I didn't think we needed that yet. The nice thing about this being a shared workflow is that if we change the config here, all services will automatically start using the new config, assuming that they are pointing to the latest trunk version of the shared workflow.