### PR TITLE
chore: product engineering team doesn't use fc-services-dev so don't write to it

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -79,7 +79,7 @@ jobs:
 
           echo; echo;
           echo "Updating values.yaml..."
-          awsenvs=( "fc-services-dev" "fc-services-stg" "fc-services-preprod" )
+          awsenvs=( "fc-services-stg" "fc-services-preprod" )
           for awsenv in "${awsenvs[@]}"
           do
             filename="cloud/aws/${awsenv}/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"


### PR DESCRIPTION
We are not using fc-services-dev as part of the normal development workflow so this github action does not need to update values.yaml in fc-services-dev.

Story details: https://app.shortcut.com/flowcode/story/46885