### PR TITLE
feat: use github sha as the image tag for nonprod workflow

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -29,7 +29,7 @@ jobs:
   cd:
     runs-on: ubuntu-latest
     env:
-      IMAGE_TAG: ${{ github.run_number }}
+      IMAGE_TAG: ${{ github.sha }}
     steps:
       -
         name: Set up Docker Context for Buildx


### PR DESCRIPTION
The github actions run_number is not that reliable since it can reset back to 1 if the workflow is updated.

Originally, I wanted to use the github PR number to tag the images built from commits that were squashed merged from PRs, but I couldn't find out how to get that, and there is no guarantee that a commit to trunk came from a PR anyway.

So, the decision is to use the commit SHA. I had already included the SHA as part of the commit message of the autogenerated commit to fc-infra-kubernetes, but this will also tag the images with that SHA.