### PR TITLE
feat: small tweaks

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -18,12 +18,6 @@ on:
         required: true
       JFROG_FLOWCODE_FC_DOCKER_REPO:
         required: true
-      PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
-        required: true
-
-permissions:
-      id-token: write    # Required for aws role assumption
-      contents: write    # This is required for actions/checkout@v1
 
 jobs:
   cd:
@@ -54,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
@@ -64,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: dtx-company/fc-infra-kubernetes
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Update the image tags in values.yaml and push commit
         run: |

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -21,6 +21,10 @@ on:
       PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
         required: true
 
+permissions:
+      id-token: write    # Required for aws role assumption
+      contents: write    # This is required for actions/checkout@v1
+
 jobs:
   cd:
     runs-on: ubuntu-latest
@@ -74,11 +78,11 @@ jobs:
           git config --local user.email ${{ github.event.pusher.email }}
 
           echo; echo;
-          echo "Updating values.yaml..."
           awsenvs=( "fc-services-stg" "fc-services-preprod" )
           for awsenv in "${awsenvs[@]}"
           do
             filename="cloud/aws/${awsenv}/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
+            echo "Updating ${filename}..."
             yq -i eval '.fc-service.process.tag = ${{ env.IMAGE_TAG }}' ${filename}
             git add ${filename}
           done

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -83,7 +83,7 @@ jobs:
           do
             filename="cloud/aws/${awsenv}/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
             echo "Updating ${filename}..."
-            yq -i eval '.fc-service.process.tag = ${{ env.IMAGE_TAG }}' ${filename}
+            yq -i eval '.fc-service.process.tag = "${{ env.IMAGE_TAG }}"' ${filename}
             git add ${filename}
           done
 

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -18,6 +18,11 @@ on:
         required: true
       JFROG_FLOWCODE_FC_DOCKER_REPO:
         required: true
+      PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
+        required: true
+
+permissions:
+      id-token: write    # Required for aws role assumption
 
 jobs:
   cd:
@@ -48,9 +53,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # cache-from: type=gha
-          # cache-to: type=gha,mode=max
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service }}:${{ env.IMAGE_TAG }}
       -
@@ -58,7 +63,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: dtx-company/fc-infra-kubernetes
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
       -
         name: Update the image tags in values.yaml and push commit
         run: |

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -18,12 +18,6 @@ on:
         required: true
       JFROG_FLOWCODE_FC_DOCKER_REPO:
         required: true
-      PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
-        required: true
-
-permissions:
-      id-token: write    # Required for aws role assumption
-      contents: write    # This is required for actions/checkout@v1
 
 jobs:
   cd:
@@ -54,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           # cache-from: type=gha
           # cache-to: type=gha,mode=max
           tags: |
@@ -64,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: dtx-company/fc-infra-kubernetes
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Update the image tags in values.yaml and push commit
         run: |

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -18,6 +18,8 @@ on:
         required: true
       JFROG_FLOWCODE_FC_DOCKER_REPO:
         required: true
+      PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
+        required: true
 
 jobs:
   cd:
@@ -48,9 +50,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
           tags: |
             ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service }}:${{ env.IMAGE_TAG }}
       -
@@ -58,7 +60,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: dtx-company/fc-infra-kubernetes
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
       -
         name: Update the image tags in values.yaml and push commit
         run: |


### PR DESCRIPTION
* Update logs
* Remove unnecessary permission since we don't use the built in GITHUB_TOKEN for the actions/checkout
* Put quotes around the image tag

Branch name is not descriptive; originally I thought we could get away with using GITHUB_TOKEN instead of passing the PAT down as a secret, but that didn't work and I ended up making a few other small changes instead.