### PR TITLE
fix: add missing fc-infra-kubernetes checkout step to prod release

### DIFF
--- a/.github/workflows/build-and-tag-and-prod-release.yaml
+++ b/.github/workflows/build-and-tag-and-prod-release.yaml
@@ -58,7 +58,7 @@ jobs:
         name: Create Github Release and Notes
         id: publish_release
         run: |
-          GITHUB_TOKEN=${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }} npx semantic-release@19
+          GITHUB_TOKEN=${{ github.token }} npx semantic-release@19
           echo ::set-output name=release_tag::$(git tag --sort committerdate | tail -1)
       -
         # Same as the nonprod workflow, except the image tag is the github release tag not the SHA.

--- a/.github/workflows/build-and-tag-and-prod-release.yaml
+++ b/.github/workflows/build-and-tag-and-prod-release.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       -
         # Checkout is required for publish_release step below to work.
-        name: Checkout repository
+        name: Checkout service repository
         uses: actions/checkout@v2
       -
         name: Set up Docker Context for Buildx
@@ -72,6 +72,12 @@ jobs:
           cache-to: type=gha,mode=max
           tags: |
             ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service }}:${{ steps.publish_release.outputs.release_tag }}
+      -
+        name: Checkout kubernetes infra repo
+        uses: actions/checkout@v2
+        with:
+          repository: dtx-company/fc-infra-kubernetes
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
       -
         # This is heavily duplicated with the nonprod workflow but it cannot be factored out
         # and reused because a reusable workflow cannot call another reusable workflow according to the docs:

--- a/.github/workflows/build-and-tag-and-prod-release.yaml
+++ b/.github/workflows/build-and-tag-and-prod-release.yaml
@@ -58,7 +58,7 @@ jobs:
         name: Create Github Release and Notes
         id: publish_release
         run: |
-          GITHUB_TOKEN=${{ github.token }} npx semantic-release@19
+          GITHUB_TOKEN=${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }} npx semantic-release@19
           echo ::set-output name=release_tag::$(git tag --sort committerdate | tail -1)
       -
         # Same as the nonprod workflow, except the image tag is the github release tag not the SHA.


### PR DESCRIPTION
Try using the personal access token instead of the Github token. Perhaps the provided github token doesn't have the right permissions.

Failed [attempt](https://github.com/dtx-company/screenshot-service/runs/6372843632?check_suite_focus=true) on screenshot-service:
```
[3:20:46 PM] [semantic-release] › ✖  An error occurred while running semantic-release: Error: Command failed with exit code 128: git ls-remote --heads https://x-access-token:[secure]@github.com/dtx-company/node-typeorm-boilerplate.git
```

A repo like screenshot-service is built from the the boilerplate [repo](https://github.com/dtx-company/node-typeorm-boilerplate) and so a custom token is likely needed.

I already tried making sure that the dtx team had read permissions to the boilerplate repo, and then I thought the built in token would have access, but that didn't work.

EDIT:

The original issue was related to something else. https://github.com/dtx-company/screenshot-service/pull/44

But also there is another fix which is that we need to check out the fc-infra-kubernetes repo which is a step I missed.