### PR TITLE
fix: set user name and email

### DIFF
--- a/.github/workflows/build-and-tag-and-prod-release.yaml
+++ b/.github/workflows/build-and-tag-and-prod-release.yaml
@@ -84,8 +84,8 @@ jobs:
 
           echo; echo;
           echo "Setting git config..."
-          git config --local user.name ${{ github.actor }}
-          git config --local user.email ${{ github.actor }}
+          git config --local user.name "${{ github.event.sender.login }}"
+          git config --local user.email "${{ github.event.sender.id }}+${{ github.event.sender.login }}@users.noreply.github.com"
 
           echo; echo;
           awsenvs=( "fc-services-prod" )


### PR DESCRIPTION
The prod workflow is triggered through manual dispatch as opposed to on a push to a branch. The previous thing I did actually didn't work; I needed to read the docs more carefully and test in the throwaway repo some more. Also, email is not available at all through the event.sender object, so I use the no-reply email which is constructed via the id and the username.