### PR TITLE
feat: Make Dockerfile path configurable

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -9,6 +9,10 @@ on:
       project:
         required: true
         type: string
+      dockerfilepath:
+        required: false
+        type: string
+        default: "./Dockerfile" # Dockerfile in the root of the repo
     secrets:
       JFROG_FLOWCODE_SERVER_NAME:
         required: true
@@ -53,6 +57,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          file: ${{ inputs.dockerfilepath }}
           github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-and-tag-and-prod-release.yaml
+++ b/.github/workflows/build-and-tag-and-prod-release.yaml
@@ -9,6 +9,10 @@ on:
       project:
         required: true
         type: string
+      dockerfilepath:
+        required: false
+        type: string
+        default: "./Dockerfile" # Dockerfile in the root of the repo
     secrets:
       JFROG_FLOWCODE_SERVER_NAME:
         required: true
@@ -67,6 +71,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          file: ${{ inputs.dockerfilepath }}
           github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Story details: https://app.shortcut.com/flowcode/story/48769

Not all of our services have the Dockerfile sitting in the root of the repo, and some services (like the flow frontend monorepo) build multiple containers and so would need to use this workflow twice, each time with a different Dockerfile specified.