### PR TITLE
feat: support updating multiple process.tag in a single values.yaml

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -97,7 +97,10 @@ jobs:
           do
             filename="cloud/aws/${awsenv}/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
             echo "Extra deployments ${{ inputs.extra-deployments }}"
-            echo (${"one,two,three"//,/ }) # test
+            test='one,two,three'
+            testarr=(${test//,/ })
+            echo $testarr
+
             deployments=(${${{ inputs.extra-deployments }}//,/ }) # split by comma into an array
             deployments+=("fc-service")                           # fc-service is always included
             echo "Updating ${filename} for deployments ${deployments}..."

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -96,12 +96,14 @@ jobs:
           for awsenv in "${awsenvs[@]}"
           do
             filename="cloud/aws/${awsenv}/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
+            echo "Extra deployments ${{ inputs.extra-deployments }}"
+            echo (${"one,two,three"//,/ }) # test
             deployments=(${${{ inputs.extra-deployments }}//,/ }) # split by comma into an array
             deployments+=("fc-service")                           # fc-service is always included
             echo "Updating ${filename} for deployments ${deployments}..."
             for d in "${deployments[@]}"
             do
-              yq -i eval '.${d}.process.tag = "${{ env.IMAGE_TAG }}"' ${filename}
+              yq -i eval '."${d}".process.tag = "${{ env.IMAGE_TAG }}"' ${filename}
             done
             git add ${filename}
           done

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -96,20 +96,11 @@ jobs:
           for awsenv in "${awsenvs[@]}"
           do
             filename="cloud/aws/${awsenv}/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
-            echo "Extra deployments ${{ inputs.extra-deployments }}"
-            test='one,two,three'
-            testarr=(${test//,/ })
-            echo $testarr
-            IFS=, read -ra testarr2 <<< "$test"
-            echo testarr2
-
-            IFS=, read -ra deployments <<< "${{ inputs.extra-deployments }}" # split by comma into an array
-            echo "Parsed extra deployments ${deployments}"
-            deployments+=("fc-service")                           # fc-service is always included
-            echo "Updating ${filename} for deployments ${deployments}..."
+            IFS=, read -ra deployments <<< "${{ inputs.extra-deployments }}"  # split by comma into an array
+            deployments+=("fc-service")                                       # fc-service is always included
+            echo "Updating ${filename} for deployments ${deployments[*]}..."
             for d in "${deployments[@]}"
             do
-              echo "${d}"
               path=".${d}.process.tag" yq -i eval 'eval(strenv(path)) = "${{ env.IMAGE_TAG }}"'  ${filename}
             done
             git add ${filename}

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -100,13 +100,17 @@ jobs:
             test='one,two,three'
             testarr=(${test//,/ })
             echo $testarr
+            IFS=, read -ra testarr2 <<< "$test"
+            echo testarr2
 
-            deployments=(${${{ inputs.extra-deployments }}//,/ }) # split by comma into an array
+            IFS=, read -ra deployments <<< "${{ inputs.extra-deployments }}" # split by comma into an array
+            echo "Parsed extra deployments ${deployments}"
             deployments+=("fc-service")                           # fc-service is always included
             echo "Updating ${filename} for deployments ${deployments}..."
             for d in "${deployments[@]}"
             do
-              yq -i eval '."${d}".process.tag = "${{ env.IMAGE_TAG }}"' ${filename}
+              echo "${d}"
+              path=".${d}.process.tag" yq -i eval 'eval(strenv(path)) = "${{ env.IMAGE_TAG }}"'  ${filename}
             done
             git add ${filename}
           done

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -6,6 +6,10 @@ on:
       service:
         required: true
         type: string
+      extra-deployments:
+        required: false
+        description: "for services that have multiple deployments in their values.yaml in fc-infra-kubernetes, provide the names of the other deployments e.g. 'worker,beat' as a comma separated list"
+        type: string
       project:
         required: true
         type: string
@@ -82,18 +86,23 @@ jobs:
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod a+x /usr/local/bin/yq
 
-          echo; echo;
+          echo;
           echo "Setting git config..."
           git config --local user.name ${{ github.event.pusher.name }}
           git config --local user.email ${{ github.event.pusher.email }}
 
-          echo; echo;
+          echo;
           awsenvs=( "fc-services-stg" "fc-services-preprod" )
           for awsenv in "${awsenvs[@]}"
           do
             filename="cloud/aws/${awsenv}/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
-            echo "Updating ${filename}..."
-            yq -i eval '.fc-service.process.tag = "${{ env.IMAGE_TAG }}"' ${filename}
+            deployments=(${${{ inputs.extra-deployments }}//,/ }) # split by comma into an array
+            deployments+=("fc-service")                           # fc-service is always included
+            echo "Updating ${filename} for deployments ${deployments}..."
+            for d in "${deployments[@]}"
+            do
+              yq -i eval '.${d}.process.tag = "${{ env.IMAGE_TAG }}"' ${filename}
+            done
             git add ${filename}
           done
 


### PR DESCRIPTION
The previous workflows assumed that our values.yaml looked like:

```
fc-service:
  process:
    tag: foo
...
```

but now they can look like:
```
fc-service:
  process:
    tag: foo

other-deployment:
  process:
    tag: foo

another-deployment:
  process:
    tag: foo
```

so my quick workaround is to let the user pass extra-deployments which will be the names of the other deployments that they wish to have the image tag continuously bumped for. This feels kind of brittle and I would prefer that everything in the deployment.yaml shared a single image tag at a known location, but this will do for now.

Tested here: https://github.com/dtx-company/notifications/pull/328
Also tested that it doesn't break when extra-deployments is not passed: https://github.com/dtx-company/payments/pull/111