### PR TITLE
feat: no need to validate single commit

### DIFF
--- a/.github/workflows/conventional-pr-title.yaml
+++ b/.github/workflows/conventional-pr-title.yaml
@@ -8,9 +8,8 @@ jobs:
     name: validate-pr-title
     runs-on: self-hosted
     steps:
+      # Configuration docs: https://github.com/marketplace/actions/semantic-pull-request#configuration
       - uses: amannn/action-semantic-pull-request@v4
-        with:
-          # Configuration docs: https://github.com/marketplace/actions/semantic-pull-request#configuration
         env:
           # GITHUB_TOKEN is available automatically.
           # See https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/#:~:text=GitHub%20Actions%20now%20lets%20you,token%20when%20a%20job%20completes.

--- a/.github/workflows/conventional-pr-title.yaml
+++ b/.github/workflows/conventional-pr-title.yaml
@@ -11,8 +11,6 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v4
         with:
           # Configuration docs: https://github.com/marketplace/actions/semantic-pull-request#configuration
-          validateSingleCommit: true
-          validateSingleCommitMatchesPrTitle: true
         env:
           # GITHUB_TOKEN is available automatically.
           # See https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/#:~:text=GitHub%20Actions%20now%20lets%20you,token%20when%20a%20job%20completes.


### PR DESCRIPTION
### Summary

- Github released a more standard way to handling this edge case -> https://github.blog/changelog/2022-05-11-default-to-pr-titles-for-squash-merge-commit-messages/
- These config options aren't needed anymore