### PR TITLE
feat: make awsenvs configurable

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: "./Dockerfile" # Dockerfile in the root of the repo
+      awsenvs:
+        required: false
+        description: "comma separate list of envs to release to, defaults to 'fc-services-stg,fc-services-preprod'"
+        type: string
+        default: "fc-services-stg,fc-services-preprod"
     secrets:
       JFROG_FLOWCODE_SERVER_NAME:
         required: true
@@ -92,7 +97,7 @@ jobs:
           git config --local user.email ${{ github.event.pusher.email }}
 
           echo;
-          awsenvs=( "fc-services-stg" "fc-services-preprod" )
+          IFS=, read -ra awsenvs <<< "${{ inputs.awsenvs }}" # get list of envs to release to
           for awsenv in "${awsenvs[@]}"
           do
             filename="cloud/aws/${awsenv}/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"


### PR DESCRIPTION
Make the awsenvs configurable so that service owners can use this workflow to release to only stg or only preprod, or whatever environments they want.

Testing in conjunction with https://github.com/dtx-company/flow/pull/6369

When awsenvs is set to only `fc-services-stg`, then it only updates the image tag in stg: https://github.com/dtx-company/fc-infra-kubernetes/commit/c12c7ffb1fb014cd57543f9afe99a9a9e925fb39