### PR TITLE
chore: allow for PYPI secrets, @barkadosh1

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -28,6 +28,10 @@ on:
         required: true
       PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
         required: true
+      JFROG_PYPI_USERNAME:
+        required: false
+      JFROG_PYPI_PASSWORD:
+        required: false
 
 permissions:
       id-token: write    # Required for aws role assumption
@@ -70,6 +74,8 @@ jobs:
           # GITHUB_USERNAME and GITHUB_PASSWORD are needed to pull private repos in the build process.
           build-args: |
             GITHUB_USERNAME=fc-cicd-rw
+            JFROG_PYPI_USERNAME=${{ secrets.JFROG_PYPI_USERNAME }}
+            JFROG_PYPI_PASSWORD=${{ secrets.JFROG_PYPI_PASSWORD }}
           secrets: |
             GITHUB_TOKEN=${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
 


### PR DESCRIPTION
The flowcode API repository needs these two secrets as well in the Build and push step. I ran the flowcode api workflow running against this PR and confirmed it is now building successfully. Additionally, you can see that the build args are being pulled in:
<img width="1376" alt="Screen Shot 2022-06-24 at 10 23 30 AM" src="https://user-images.githubusercontent.com/47760522/175556130-e29d4ea5-99e7-4fc1-83a5-8f59bc0b3b4c.png">
