### PR TITLE
chore: standardize pypi secret names, @barkadosh1

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -28,9 +28,9 @@ on:
         required: true
       PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
         required: true
-      JFROG_PYPI_USERNAME:
+      JFROG_FLOWCODE_FC_PYPI_USERNAME:
         required: false
-      JFROG_PYPI_PASSWORD:
+      JFROG_FLOWCODE_FC_PYPI_PASSWORD:
         required: false
 
 permissions:
@@ -74,8 +74,8 @@ jobs:
           # GITHUB_USERNAME and GITHUB_PASSWORD are needed to pull private repos in the build process.
           build-args: |
             GITHUB_USERNAME=fc-cicd-rw
-            JFROG_PYPI_USERNAME=${{ secrets.JFROG_PYPI_USERNAME }}
-            JFROG_PYPI_PASSWORD=${{ secrets.JFROG_PYPI_PASSWORD }}
+            JFROG_FLOWCODE_FC_PYPI_USERNAME=${{ secrets.JFROG_FLOWCODE_FC_PYPI_USERNAME }}
+            JFROG_FLOWCODE_FC_PYPI_PASSWORD=${{ secrets.JFROG_FLOWCODE_FC_PYPI_PASSWORD }}
           secrets: |
             GITHUB_TOKEN=${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
 


### PR DESCRIPTION
Updating the non prod shared workflow to use the org-level secrets that james added.

I ran these changes with changes in Flowcode API (PR to be opened shortly) to test that the new secrets were being pulled in and the build succeeded. See new secrets in the build command below:
<img width="1417" alt="Screen Shot 2022-06-24 at 3 03 29 PM" src="https://user-images.githubusercontent.com/47760522/175649057-f512933a-ca8d-43c2-abfb-aa957d5ef8b0.png">
