### PR TITLE
feat: support AWS region in addition to AWS account

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -19,9 +19,9 @@ on:
         default: "./Dockerfile" # Dockerfile in the root of the repo
       awsenvs:
         required: false
-        description: "comma separate list of envs to release to, defaults to 'fc-services-stg,fc-services-preprod'"
+        description: "comma separate list of envs to release to, defaults to 'fc-services-stg/use1,fc-services-preprod/use1'"
         type: string
-        default: "fc-services-stg,fc-services-preprod"
+        default: "fc-services-stg/use1,fc-services-preprod/use1"
     secrets:
       JFROG_FLOWCODE_SERVER_NAME:
         required: true
@@ -106,7 +106,7 @@ jobs:
           IFS=, read -ra awsenvs <<< "${{ inputs.awsenvs }}" # get list of envs to release to
           for awsenv in "${awsenvs[@]}"
           do
-            filename="cloud/aws/${awsenv}/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
+            filename="cloud/aws/${awsenv}/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
             IFS=, read -ra deployments <<< "${{ inputs.extra-deployments }}"  # split by comma into an array
             deployments+=("fc-service")                                       # fc-service is always included
             echo "Updating ${filename} for deployments ${deployments[*]}..."

--- a/.github/workflows/build-and-tag-and-prod-release.yaml
+++ b/.github/workflows/build-and-tag-and-prod-release.yaml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: "./Dockerfile" # Dockerfile in the root of the repo
+      awsenvs:
+        required: false
+        description: "comma separate list of envs to release to, defaults to 'fc-services-prod/use1'"
+        type: string
+        default: "fc-services-prod/use1"
     secrets:
       JFROG_FLOWCODE_SERVER_NAME:
         required: true
@@ -114,10 +119,10 @@ jobs:
           git config --local user.email "${{ github.event.sender.id }}+${{ github.event.sender.login }}@users.noreply.github.com"
 
           echo;
-          awsenvs=( "fc-services-prod" )
+          IFS=, read -ra awsenvs <<< "${{ inputs.awsenvs }}" # get list of envs to release to
           for awsenv in "${awsenvs[@]}"
           do
-            filename="cloud/aws/${awsenv}/use1/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
+            filename="cloud/aws/${awsenv}/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
             IFS=, read -ra deployments <<< "${{ inputs.extra-deployments }}"  # split by comma into an array
             deployments+=("fc-service")                                       # fc-service is always included
             echo "Updating ${filename} for deployments ${deployments[*]}..."


### PR DESCRIPTION
To release to usw2 prod, I need to update the workflows to allow the caller to specify multiple regions if they choose. The default for prod is "fc-services-prod/use1", but we could set it to "fc-services-prod/use1,fc-services-prod/usw2" to release to both.

Previously, only the account was configurable and this was already tested. None of the workflow callers are actually setting awsenvs yet, so even though this change is technically a breaking change, it doesn't break any existing callers.