### PR TITLE
feat: support post-build-script and docker-build-args

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -90,7 +90,7 @@ jobs:
 
       -
         name: Run post-build script
-        if: inputs.post-build-script != ""
+        if: inputs.post-build-script != ''
         run: |
           ./${{ inputs.post-build-script }}
 

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -17,6 +17,10 @@ on:
         required: false
         type: string
         default: "./Dockerfile" # Dockerfile in the root of the repo
+      docker-build-args:
+        required: false
+        type: string
+        description: "comma separated list of non-secret arguments to pass to the docker build, e.g. 'APP_ENV=stg,FOO=foo'"
       awsenvs:
         required: false
         description: "comma separated list of envs to release to, defaults to 'fc-services-stg/use1,fc-services-preprod/use1'"
@@ -88,11 +92,16 @@ jobs:
           cache-to: type=gha,mode=max
           tags: |
             ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service }}:${{ env.IMAGE_TAG }}
-          # GITHUB_USERNAME and GITHUB_PASSWORD are needed to pull private repos in the build process.
+          # GITHUB_USERNAME and GITHUB_TOKEN are needed to pull private repos in the build process.
+          # JFROG_FLOWCODE_FC_PYPI_USERNAME and JFROG_FLOWCODE_FC_PYPI_PASSWORD are needed to pull from private pypi repos.
+          # VERSION and BUILD_ID are used by the flow frontend build process for datadog logging.
           build-args: |
             GITHUB_USERNAME=fc-cicd-rw
             JFROG_FLOWCODE_FC_PYPI_USERNAME=${{ secrets.JFROG_FLOWCODE_FC_PYPI_USERNAME }}
             JFROG_FLOWCODE_FC_PYPI_PASSWORD=${{ secrets.JFROG_FLOWCODE_FC_PYPI_PASSWORD }}
+            VERSION=${{ env.IMAGE_TAG }}
+            ${{ inputs.docker-build-args }}
+
           secrets: |
             GITHUB_TOKEN=${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
       -

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -96,6 +96,11 @@ jobs:
       -
         name: Run post-build script
         if: inputs.post-build-script != ''
+        env:
+          # Don't edit or delete these without confirming it won't break the scripts that use them.
+          JFROG_FLOWCODE_SERVER_NAME: ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}
+          JFROG_FLOWCODE_FC_DOCKER_REPO: ${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}
+          SERVICE_NAME: ${{ inputs.service }}
         run: |
           ./${{ inputs.post-build-script }}
       -

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -92,6 +92,9 @@ jobs:
         name: Checkout repo to run post-build script
         if: inputs.post-build-script != ''
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+
 
       -
         name: Run post-build script

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -99,7 +99,7 @@ jobs:
             GITHUB_USERNAME=fc-cicd-rw
             JFROG_FLOWCODE_FC_PYPI_USERNAME=${{ secrets.JFROG_FLOWCODE_FC_PYPI_USERNAME }}
             JFROG_FLOWCODE_FC_PYPI_PASSWORD=${{ secrets.JFROG_FLOWCODE_FC_PYPI_PASSWORD }}
-            BUILD_ID=${{ env.IMAGE_TAG }}
+            BUILD_ID=${{ inputs.service }}-${{ env.IMAGE_TAG }}
             VERSION=${{ env.IMAGE_TAG }}
             ${{ inputs.docker-build-args }}
 

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -103,45 +103,45 @@ jobs:
           SERVICE_NAME: ${{ inputs.service }}
         run: |
           ./${{ inputs.post-build-script }}
-      -
-        name: Checkout kubernetes infra repo
-        uses: actions/checkout@v2
-        with:
-          repository: dtx-company/fc-infra-kubernetes
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
-      -
-        name: Update the image tags in values.yaml and push commit
-        run: |
-          echo "Installing yq..."
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod a+x /usr/local/bin/yq
+      # -
+      #   name: Checkout kubernetes infra repo
+      #   uses: actions/checkout@v2
+      #   with:
+      #     repository: dtx-company/fc-infra-kubernetes
+      #     token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+      # -
+      #   name: Update the image tags in values.yaml and push commit
+      #   run: |
+      #     echo "Installing yq..."
+      #     sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+      #     sudo chmod a+x /usr/local/bin/yq
 
-          echo;
-          echo "Setting git config..."
-          git config --local user.name ${{ github.event.pusher.name }}
-          git config --local user.email ${{ github.event.pusher.email }}
+      #     echo;
+      #     echo "Setting git config..."
+      #     git config --local user.name ${{ github.event.pusher.name }}
+      #     git config --local user.email ${{ github.event.pusher.email }}
 
-          echo;
-          IFS=, read -ra awsenvs <<< "${{ inputs.awsenvs }}" # get list of envs to release to
-          for awsenv in "${awsenvs[@]}"
-          do
-            filename="cloud/aws/${awsenv}/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
-            IFS=, read -ra deployments <<< "${{ inputs.extra-deployments }}"  # split by comma into an array
-            deployments+=("fc-service")                                       # fc-service is always included
-            echo "Updating ${filename} for deployments ${deployments[*]}..."
-            for d in "${deployments[@]}"
-            do
-              path=".${d}.process.tag" yq -i eval 'eval(strenv(path)) = "${{ env.IMAGE_TAG }}"'  ${filename}
-            done
-            git add ${filename}
-          done
+      #     echo;
+      #     IFS=, read -ra awsenvs <<< "${{ inputs.awsenvs }}" # get list of envs to release to
+      #     for awsenv in "${awsenvs[@]}"
+      #     do
+      #       filename="cloud/aws/${awsenv}/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
+      #       IFS=, read -ra deployments <<< "${{ inputs.extra-deployments }}"  # split by comma into an array
+      #       deployments+=("fc-service")                                       # fc-service is always included
+      #       echo "Updating ${filename} for deployments ${deployments[*]}..."
+      #       for d in "${deployments[@]}"
+      #       do
+      #         path=".${d}.process.tag" yq -i eval 'eval(strenv(path)) = "${{ env.IMAGE_TAG }}"'  ${filename}
+      #       done
+      #       git add ${filename}
+      #     done
 
-          echo; echo;
-          echo "Pushing to git..."
-          git diff HEAD
-          if [[ $(git diff HEAD) ]]; then
-            git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}" -m "triggered from https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
-            git push origin HEAD
-          else
-            echo "Nothing to push"
-          fi
+      #     echo; echo;
+      #     echo "Pushing to git..."
+      #     git diff HEAD
+      #     if [[ $(git diff HEAD) ]]; then
+      #       git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}" -m "triggered from https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
+      #       git push origin HEAD
+      #     else
+      #       echo "Nothing to push"
+      #     fi

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -125,45 +125,45 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY }}
         run: |
           ./${{ inputs.post-build-script }}
-      # -
-      #   name: Checkout kubernetes infra repo
-      #   uses: actions/checkout@v2
-      #   with:
-      #     repository: dtx-company/fc-infra-kubernetes
-      #     token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
-      # -
-      #   name: Update the image tags in values.yaml and push commit
-      #   run: |
-      #     echo "Installing yq..."
-      #     sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-      #     sudo chmod a+x /usr/local/bin/yq
+      -
+        name: Checkout kubernetes infra repo
+        uses: actions/checkout@v2
+        with:
+          repository: dtx-company/fc-infra-kubernetes
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+      -
+        name: Update the image tags in values.yaml and push commit
+        run: |
+          echo "Installing yq..."
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod a+x /usr/local/bin/yq
 
-      #     echo;
-      #     echo "Setting git config..."
-      #     git config --local user.name ${{ github.event.pusher.name }}
-      #     git config --local user.email ${{ github.event.pusher.email }}
+          echo;
+          echo "Setting git config..."
+          git config --local user.name ${{ github.event.pusher.name }}
+          git config --local user.email ${{ github.event.pusher.email }}
 
-      #     echo;
-      #     IFS=, read -ra awsenvs <<< "${{ inputs.awsenvs }}" # get list of envs to release to
-      #     for awsenv in "${awsenvs[@]}"
-      #     do
-      #       filename="cloud/aws/${awsenv}/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
-      #       IFS=, read -ra deployments <<< "${{ inputs.extra-deployments }}"  # split by comma into an array
-      #       deployments+=("fc-service")                                       # fc-service is always included
-      #       echo "Updating ${filename} for deployments ${deployments[*]}..."
-      #       for d in "${deployments[@]}"
-      #       do
-      #         path=".${d}.process.tag" yq -i eval 'eval(strenv(path)) = "${{ env.IMAGE_TAG }}"'  ${filename}
-      #       done
-      #       git add ${filename}
-      #     done
+          echo;
+          IFS=, read -ra awsenvs <<< "${{ inputs.awsenvs }}" # get list of envs to release to
+          for awsenv in "${awsenvs[@]}"
+          do
+            filename="cloud/aws/${awsenv}/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
+            IFS=, read -ra deployments <<< "${{ inputs.extra-deployments }}"  # split by comma into an array
+            deployments+=("fc-service")                                       # fc-service is always included
+            echo "Updating ${filename} for deployments ${deployments[*]}..."
+            for d in "${deployments[@]}"
+            do
+              path=".${d}.process.tag" yq -i eval 'eval(strenv(path)) = "${{ env.IMAGE_TAG }}"'  ${filename}
+            done
+            git add ${filename}
+          done
 
-      #     echo; echo;
-      #     echo "Pushing to git..."
-      #     git diff HEAD
-      #     if [[ $(git diff HEAD) ]]; then
-      #       git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}" -m "triggered from https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
-      #       git push origin HEAD
-      #     else
-      #       echo "Nothing to push"
-      #     fi
+          echo; echo;
+          echo "Pushing to git..."
+          git diff HEAD
+          if [[ $(git diff HEAD) ]]; then
+            git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}" -m "triggered from https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
+            git push origin HEAD
+          else
+            echo "Nothing to push"
+          fi

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -20,7 +20,7 @@ on:
       docker-build-args:
         required: false
         type: string
-        description: "comma separated list of non-secret arguments to pass to the docker build, e.g. 'APP_ENV=stg,FOO=foo'"
+        description: "newline separated list of non-secret arguments to pass to the docker build, e.g. 'APP_ENV=stg\nFOO=foo'"
       awsenvs:
         required: false
         description: "comma separated list of envs to release to, defaults to 'fc-services-stg/use1,fc-services-preprod/use1'"
@@ -94,11 +94,12 @@ jobs:
             ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}/${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}/${{ inputs.service }}:${{ env.IMAGE_TAG }}
           # GITHUB_USERNAME and GITHUB_TOKEN are needed to pull private repos in the build process.
           # JFROG_FLOWCODE_FC_PYPI_USERNAME and JFROG_FLOWCODE_FC_PYPI_PASSWORD are needed to pull from private pypi repos.
-          # VERSION and BUILD_ID are used by the flow frontend build process for datadog logging.
+          # VERSION and BUILD_ID are used by the flow frontend build process.
           build-args: |
             GITHUB_USERNAME=fc-cicd-rw
             JFROG_FLOWCODE_FC_PYPI_USERNAME=${{ secrets.JFROG_FLOWCODE_FC_PYPI_USERNAME }}
             JFROG_FLOWCODE_FC_PYPI_PASSWORD=${{ secrets.JFROG_FLOWCODE_FC_PYPI_PASSWORD }}
+            BUILD_ID=${{ env.IMAGE_TAG }}
             VERSION=${{ env.IMAGE_TAG }}
             ${{ inputs.docker-build-args }}
 

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -19,12 +19,16 @@ on:
         default: "./Dockerfile" # Dockerfile in the root of the repo
       awsenvs:
         required: false
-        description: "comma separate list of envs to release to, defaults to 'fc-services-stg/use1,fc-services-preprod/use1'"
+        description: "comma separated list of envs to release to, defaults to 'fc-services-stg/use1,fc-services-preprod/use1'"
         type: string
         default: "fc-services-stg/use1,fc-services-preprod/use1"
       post-build-script:
         required: false
         description: "file path of a shell script to run between the build step and the release step, e.g. 'scripts/myscript.sh'"
+        type: string
+      post-build-script-inputs:
+        required: false
+        description: "json string to pass to the post-build-script"
         type: string
     secrets:
       JFROG_FLOWCODE_SERVER_NAME:
@@ -41,9 +45,13 @@ on:
         required: false
       JFROG_FLOWCODE_FC_PYPI_PASSWORD:
         required: false
+      STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID:
+        required: false
+      STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY:
+        required: false
 
 permissions:
-      id-token: write    # Required for aws role assumption
+  id-token: write    # Required for aws role assumption
 
 jobs:
   cd:
@@ -101,6 +109,10 @@ jobs:
           JFROG_FLOWCODE_SERVER_NAME: ${{ secrets.JFROG_FLOWCODE_SERVER_NAME }}
           JFROG_FLOWCODE_FC_DOCKER_REPO: ${{ secrets.JFROG_FLOWCODE_FC_DOCKER_REPO }}
           SERVICE_NAME: ${{ inputs.service }}
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          POST_BUILD_SCRIPT_INPUTS: ${{ inputs.post-build-script-inputs }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY }}
         run: |
           ./${{ inputs.post-build-script }}
       # -

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -87,60 +87,56 @@ jobs:
             JFROG_FLOWCODE_FC_PYPI_PASSWORD=${{ secrets.JFROG_FLOWCODE_FC_PYPI_PASSWORD }}
           secrets: |
             GITHUB_TOKEN=${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
-
       -
         name: Checkout repo to run post-build script
         if: inputs.post-build-script != ''
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
-
-
       -
         name: Run post-build script
         if: inputs.post-build-script != ''
         run: |
           ./${{ inputs.post-build-script }}
+      -
+        name: Checkout kubernetes infra repo
+        uses: actions/checkout@v2
+        with:
+          repository: dtx-company/fc-infra-kubernetes
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+      -
+        name: Update the image tags in values.yaml and push commit
+        run: |
+          echo "Installing yq..."
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod a+x /usr/local/bin/yq
 
-      # -
-      #   name: Checkout kubernetes infra repo
-      #   uses: actions/checkout@v2
-      #   with:
-      #     repository: dtx-company/fc-infra-kubernetes
-      #     token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
-      # -
-      #   name: Update the image tags in values.yaml and push commit
-      #   run: |
-      #     echo "Installing yq..."
-      #     sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-      #     sudo chmod a+x /usr/local/bin/yq
+          echo;
+          echo "Setting git config..."
+          git config --local user.name ${{ github.event.pusher.name }}
+          git config --local user.email ${{ github.event.pusher.email }}
 
-      #     echo;
-      #     echo "Setting git config..."
-      #     git config --local user.name ${{ github.event.pusher.name }}
-      #     git config --local user.email ${{ github.event.pusher.email }}
+          echo;
+          IFS=, read -ra awsenvs <<< "${{ inputs.awsenvs }}" # get list of envs to release to
+          for awsenv in "${awsenvs[@]}"
+          do
+            filename="cloud/aws/${awsenv}/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
+            IFS=, read -ra deployments <<< "${{ inputs.extra-deployments }}"  # split by comma into an array
+            deployments+=("fc-service")                                       # fc-service is always included
+            echo "Updating ${filename} for deployments ${deployments[*]}..."
+            for d in "${deployments[@]}"
+            do
+              path=".${d}.process.tag" yq -i eval 'eval(strenv(path)) = "${{ env.IMAGE_TAG }}"'  ${filename}
+            done
+            git add ${filename}
+          done
 
-      #     echo;
-      #     IFS=, read -ra awsenvs <<< "${{ inputs.awsenvs }}" # get list of envs to release to
-      #     for awsenv in "${awsenvs[@]}"
-      #     do
-      #       filename="cloud/aws/${awsenv}/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
-      #       IFS=, read -ra deployments <<< "${{ inputs.extra-deployments }}"  # split by comma into an array
-      #       deployments+=("fc-service")                                       # fc-service is always included
-      #       echo "Updating ${filename} for deployments ${deployments[*]}..."
-      #       for d in "${deployments[@]}"
-      #       do
-      #         path=".${d}.process.tag" yq -i eval 'eval(strenv(path)) = "${{ env.IMAGE_TAG }}"'  ${filename}
-      #       done
-      #       git add ${filename}
-      #     done
-
-      #     echo; echo;
-      #     echo "Pushing to git..."
-      #     git diff HEAD
-      #     if [[ $(git diff HEAD) ]]; then
-      #       git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}" -m "triggered from https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
-      #       git push origin HEAD
-      #     else
-      #       echo "Nothing to push"
-      #     fi
+          echo; echo;
+          echo "Pushing to git..."
+          git diff HEAD
+          if [[ $(git diff HEAD) ]]; then
+            git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}" -m "triggered from https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
+            git push origin HEAD
+          else
+            echo "Nothing to push"
+          fi

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -22,6 +22,10 @@ on:
         description: "comma separate list of envs to release to, defaults to 'fc-services-stg/use1,fc-services-preprod/use1'"
         type: string
         default: "fc-services-stg/use1,fc-services-preprod/use1"
+      post-build-script:
+        required: false
+        description: "file path of a shell script to run between the build step and the release step, e.g. 'scripts/myscript.sh'"
+        type: string
     secrets:
       JFROG_FLOWCODE_SERVER_NAME:
         required: true
@@ -85,44 +89,50 @@ jobs:
             GITHUB_TOKEN=${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
 
       -
-        name: Checkout kubernetes infra repo
-        uses: actions/checkout@v2
-        with:
-          repository: dtx-company/fc-infra-kubernetes
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
-      -
-        name: Update the image tags in values.yaml and push commit
+        name: Run post-build script
+        if: inputs.post-build-script != ""
         run: |
-          echo "Installing yq..."
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod a+x /usr/local/bin/yq
+          ./${{ inputs.post-build-script }}
 
-          echo;
-          echo "Setting git config..."
-          git config --local user.name ${{ github.event.pusher.name }}
-          git config --local user.email ${{ github.event.pusher.email }}
+      # -
+      #   name: Checkout kubernetes infra repo
+      #   uses: actions/checkout@v2
+      #   with:
+      #     repository: dtx-company/fc-infra-kubernetes
+      #     token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+      # -
+      #   name: Update the image tags in values.yaml and push commit
+      #   run: |
+      #     echo "Installing yq..."
+      #     sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+      #     sudo chmod a+x /usr/local/bin/yq
 
-          echo;
-          IFS=, read -ra awsenvs <<< "${{ inputs.awsenvs }}" # get list of envs to release to
-          for awsenv in "${awsenvs[@]}"
-          do
-            filename="cloud/aws/${awsenv}/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
-            IFS=, read -ra deployments <<< "${{ inputs.extra-deployments }}"  # split by comma into an array
-            deployments+=("fc-service")                                       # fc-service is always included
-            echo "Updating ${filename} for deployments ${deployments[*]}..."
-            for d in "${deployments[@]}"
-            do
-              path=".${d}.process.tag" yq -i eval 'eval(strenv(path)) = "${{ env.IMAGE_TAG }}"'  ${filename}
-            done
-            git add ${filename}
-          done
+      #     echo;
+      #     echo "Setting git config..."
+      #     git config --local user.name ${{ github.event.pusher.name }}
+      #     git config --local user.email ${{ github.event.pusher.email }}
 
-          echo; echo;
-          echo "Pushing to git..."
-          git diff HEAD
-          if [[ $(git diff HEAD) ]]; then
-            git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}" -m "triggered from https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
-            git push origin HEAD
-          else
-            echo "Nothing to push"
-          fi
+      #     echo;
+      #     IFS=, read -ra awsenvs <<< "${{ inputs.awsenvs }}" # get list of envs to release to
+      #     for awsenv in "${awsenvs[@]}"
+      #     do
+      #       filename="cloud/aws/${awsenv}/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
+      #       IFS=, read -ra deployments <<< "${{ inputs.extra-deployments }}"  # split by comma into an array
+      #       deployments+=("fc-service")                                       # fc-service is always included
+      #       echo "Updating ${filename} for deployments ${deployments[*]}..."
+      #       for d in "${deployments[@]}"
+      #       do
+      #         path=".${d}.process.tag" yq -i eval 'eval(strenv(path)) = "${{ env.IMAGE_TAG }}"'  ${filename}
+      #       done
+      #       git add ${filename}
+      #     done
+
+      #     echo; echo;
+      #     echo "Pushing to git..."
+      #     git diff HEAD
+      #     if [[ $(git diff HEAD) ]]; then
+      #       git commit -m "cicd-auto: nonprod bump ${{ inputs.service }} to ${{ env.IMAGE_TAG }}" -m "triggered from https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
+      #       git push origin HEAD
+      #     else
+      #       echo "Nothing to push"
+      #     fi

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -89,6 +89,11 @@ jobs:
             GITHUB_TOKEN=${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
 
       -
+        name: Checkout repo to run post-build script
+        if: inputs.post-build-script != ''
+        uses: actions/checkout@v2
+
+      -
         name: Run post-build script
         if: inputs.post-build-script != ''
         run: |


### PR DESCRIPTION
Allow the caller to pass in a script to run after the build step and before the release step.

The specific use case is for the flow-app service, which wants to run a specific step after the docker build to push static assets to S3. And flow-app also requires the presence of several build args during the docker build step.