### PR TITLE
feat: set possible types for conventional-pr-title

### DIFF
--- a/.github/workflows/conventional-pr-title.yaml
+++ b/.github/workflows/conventional-pr-title.yaml
@@ -10,6 +10,16 @@ jobs:
     steps:
       # Configuration docs: https://github.com/marketplace/actions/semantic-pull-request#configuration
       - uses: amannn/action-semantic-pull-request@v4
+        with:
+          types: |
+            build
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            test
         env:
           # GITHUB_TOKEN is available automatically.
           # See https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/#:~:text=GitHub%20Actions%20now%20lets%20you,token%20when%20a%20job%20completes.


### PR DESCRIPTION
### Summary

- matches up with angular convention that the release-notes use
- Slack Convo -> https://flowcode.slack.com/archives/C0271ESGNFQ/p1657718464221249?thread_ts=1657718325.067559&cid=C0271ESGNFQ

The default for this action is from commitzen -> https://github.com/commitizen/conventional-commit-types/blob/master/index.json

Which contains some other types that the release-notes doesn't have