### PR TITLE
feat: use conventionalcommit standard and add custom types

### DIFF
--- a/.github/workflows/build-and-tag-and-prod-release.yaml
+++ b/.github/workflows/build-and-tag-and-prod-release.yaml
@@ -75,6 +75,7 @@ jobs:
         name: Create Github Release and Notes
         id: publish_release
         run: |
+          npm i conventional-changelog-conventionalcommits
           GITHUB_TOKEN=${{ github.token }} npx semantic-release@19
           echo ::set-output name=release_tag::$(git tag --sort committerdate | tail -1)
       -

--- a/.github/workflows/conventional-pr-title.yaml
+++ b/.github/workflows/conventional-pr-title.yaml
@@ -18,7 +18,6 @@ jobs:
             ci
             docs
             feat
-            feature
             fix
             perf
             refactor

--- a/.github/workflows/conventional-pr-title.yaml
+++ b/.github/workflows/conventional-pr-title.yaml
@@ -9,16 +9,21 @@ jobs:
     runs-on: self-hosted
     steps:
       # Configuration docs: https://github.com/marketplace/actions/semantic-pull-request#configuration
+      # We allow types based on conventionalcommit standard: https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/writer-opts.js#L179-L192
       - uses: amannn/action-semantic-pull-request@v4
         with:
           types: |
             build
+            chore
             ci
             docs
             feat
+            feature
             fix
             perf
             refactor
+            revert
+            style
             test
         env:
           # GITHUB_TOKEN is available automatically.


### PR DESCRIPTION
I'm experimenting with using the conventionalcommit standard instead of the angular standard. The conventionalcommit standard allows a few more types, most notably 'chore', which is heavily used by our engineers and so we want to support it.

