### PR TITLE
feat: make the action runner configurable

### DIFF
--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -6,7 +6,7 @@ on:
       runner:
         required: false
         type: string
-        default: self-hosted
+        default: "self-hosted"
         description: "the github runner to run on, options are {ubuntu-latest, self-hosted, frontend}"
       service:
         required: true

--- a/.github/workflows/build-and-push-and-nonprod-release.yaml
+++ b/.github/workflows/build-and-push-and-nonprod-release.yaml
@@ -3,6 +3,11 @@ name: build-and-push-and-nonprod-release
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: self-hosted
+        description: "the github runner to run on, options are {ubuntu-latest, self-hosted, frontend}"
       service:
         required: true
         type: string
@@ -59,7 +64,7 @@ permissions:
 
 jobs:
   cd:
-    runs-on: self-hosted
+    runs-on: ${{ inputs.runner }}
     env:
       IMAGE_TAG: ${{ github.sha }}
     steps:

--- a/.github/workflows/build-and-tag-and-prod-release.yaml
+++ b/.github/workflows/build-and-tag-and-prod-release.yaml
@@ -6,7 +6,7 @@ on:
       runner:
         required: false
         type: string
-        default: self-hosted
+        default: "self-hosted"
         description: "the github runner to run on, options are {ubuntu-latest, self-hosted, frontend}"
       service:
         required: true

--- a/.github/workflows/build-and-tag-and-prod-release.yaml
+++ b/.github/workflows/build-and-tag-and-prod-release.yaml
@@ -3,6 +3,11 @@ name: build-and-tag-and-prod-release
 on:
   workflow_call:
     inputs:
+      runner:
+        required: false
+        type: string
+        default: self-hosted
+        description: "the github runner to run on, options are {ubuntu-latest, self-hosted, frontend}"
       service:
         required: true
         type: string
@@ -40,7 +45,7 @@ on:
 
 jobs:
   release:
-    runs-on: self-hosted
+    runs-on: ${{ inputs.runner }}
     steps:
       -
         # Checkout is required for publish_release step below to work.


### PR DESCRIPTION
Make the github actions runner configurable. Still defaults to the generic self-hosted. The reason for this change is primarily to get the frontend builds to run on their own dedicated runners that are bulkier and have node preinstalled among other things. In the future we may have optimized runners to support different service types like our Django or Go services.