### PR TITLE
feat: use shared config for semantic release

### DIFF
--- a/.github/workflows/build-and-tag-and-prod-release.yaml
+++ b/.github/workflows/build-and-tag-and-prod-release.yaml
@@ -36,10 +36,6 @@ on:
         required: true
       JFROG_FLOWCODE_FC_DOCKER_REPO:
         required: true
-      JFROG_FLOWCODE_FC_NPM_USERNAME:
-        required: true
-      JFROG_FLOWCODE_FC_NPM_PASSWORD_B64:
-        required: true
       PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
         required: true
       JFROG_FLOWCODE_FC_PYPI_USERNAME:
@@ -55,13 +51,6 @@ jobs:
         # Checkout is required for publish_release step below to work.
         name: Checkout service repository
         uses: actions/checkout@v3
-      -
-        # Checkout is required to pull in the .npmrc
-        name: Checkout shared-github-workflows repository
-        uses: actions/checkout@v3
-        with:
-          repository: dtx-company/shared-github-workflows
-          path: shared
       -
         name: Set up Docker Context for Buildx
         id: buildx-context
@@ -91,12 +80,9 @@ jobs:
         name: Create Github Release and Notes
         id: publish_release
         run: |
-          npm i @flowcode/semantic-release-fc-shared-config --userconfig=./shared/config/.npmrc
+          npm i @flowcode/semantic-release-fc-shared-config
           GITHUB_TOKEN=${{ github.token }} npx semantic-release@19 -e @flowcode/semantic-release-fc-shared-config
           echo ::set-output name=release_tag::$(git tag --sort committerdate | tail -1)
-        env:
-          JFROG_FC_NPM_USERNAME: ${{ secrets.JFROG_FLOWCODE_FC_NPM_USERNAME }}
-          JFROG_FC_NPM_PASSWORD_B64: ${{ secrets.JFROG_FLOWCODE_FC_NPM_PASSWORD_B64 }}
       -
         # Same as the nonprod workflow, except the image tag is the github release tag not the SHA.
         name: Build and push

--- a/.github/workflows/build-and-tag-and-prod-release.yaml
+++ b/.github/workflows/build-and-tag-and-prod-release.yaml
@@ -36,6 +36,10 @@ on:
         required: true
       JFROG_FLOWCODE_FC_DOCKER_REPO:
         required: true
+      JFROG_FLOWCODE_FC_NPM_USERNAME:
+        required: true
+      JFROG_FLOWCODE_FC_NPM_PASSWORD_B64:
+        required: true
       PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
         required: true
       JFROG_FLOWCODE_FC_PYPI_USERNAME:
@@ -50,7 +54,14 @@ jobs:
       -
         # Checkout is required for publish_release step below to work.
         name: Checkout service repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      -
+        # Checkout is required to pull in the .npmrc
+        name: Checkout shared-github-workflows repository
+        uses: actions/checkout@v3
+        with:
+          repository: dtx-company/shared-github-workflows
+          path: shared
       -
         name: Set up Docker Context for Buildx
         id: buildx-context
@@ -71,7 +82,7 @@ jobs:
       -
         # Node is required -- is it already provided on our machines or is it necessary to set it up as a step?
         name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
       -
@@ -80,9 +91,12 @@ jobs:
         name: Create Github Release and Notes
         id: publish_release
         run: |
-          npm i conventional-changelog-conventionalcommits
-          GITHUB_TOKEN=${{ github.token }} npx semantic-release@19
+          npm i @flowcode/semantic-release-fc-shared-config --userconfig=./shared/config/.npmrc
+          GITHUB_TOKEN=${{ github.token }} npx semantic-release@19 -e @flowcode/semantic-release-fc-shared-config
           echo ::set-output name=release_tag::$(git tag --sort committerdate | tail -1)
+        env:
+          JFROG_FC_NPM_USERNAME: ${{ secrets.JFROG_FLOWCODE_FC_NPM_USERNAME }}
+          JFROG_FC_NPM_PASSWORD_B64: ${{ secrets.JFROG_FLOWCODE_FC_NPM_PASSWORD_B64 }}
       -
         # Same as the nonprod workflow, except the image tag is the github release tag not the SHA.
         name: Build and push


### PR DESCRIPTION
### Summary

- used a shared-config publish to jfrog

### Todo:

- [x] (https://github.com/dtx-company/sre-infra-terraform/pull/323)