### PR TITLE
feat: add .npmrc

### DIFF
--- a/config/.npmrc
+++ b/config/.npmrc
@@ -1,0 +1,6 @@
+always-auth=true
+@flowcode:registry=https://flowcode.jfrog.io/artifactory/api/npm/fc-npm/
+//flowcode.jfrog.io/artifactory/api/npm/fc-npm/:_password=${JFROG_FC_NPM_PASSWORD_B64}
+//flowcode.jfrog.io/artifactory/api/npm/fc-npm/:username=${JFROG_FC_NPM_USERNAME}
+//flowcode.jfrog.io/artifactory/api/npm/fc-npm/:email=admin@admin.com
+//flowcode.jfrog.io/artifactory/api/npm/fc-npm/:always-auth=true


### PR DESCRIPTION
### Summary

- This is needed in order for npm to know which registry the global config lives and how to authenticate