### PR TITLE
chore: remove 'style' as an option

### DIFF
--- a/.github/workflows/conventional-pr-title.yaml
+++ b/.github/workflows/conventional-pr-title.yaml
@@ -22,7 +22,6 @@ jobs:
             perf
             refactor
             revert
-            style
             test
         env:
           # GITHUB_TOKEN is available automatically.


### PR DESCRIPTION
We agreed in FlowTech that we don't need 'style' as a commit type.