### PR TITLE
feat: add input to target specific commit for releasing'

### DIFF
--- a/.github/workflows/build-and-tag-and-prod-release.yaml
+++ b/.github/workflows/build-and-tag-and-prod-release.yaml
@@ -76,7 +76,7 @@ jobs:
           username: ${{ secrets.JFROG_FLOWCODE_FC_DOCKER_USERNAME }}
           password: ${{ secrets.JFROG_FLOWCODE_FC_DOCKER_PASSWORD }}
       -
-        # Node.js install is required
+        # Node.js install is required -- is it already provided on our machines or is it necessary to set it up as a step?
         name: Setup Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build-and-tag-and-prod-release.yaml
+++ b/.github/workflows/build-and-tag-and-prod-release.yaml
@@ -3,6 +3,11 @@ name: build-and-tag-and-prod-release
 on:
   workflow_call:
     inputs:
+      release-ref:
+        required: false
+        type: string
+        default: ''
+        description: "The branch, tag or SHA to checkout"
       runner:
         required: false
         type: string
@@ -51,6 +56,8 @@ jobs:
         # Checkout is required for publish_release step below to work.
         name: Checkout service repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.release-ref}}
       -
         name: Set up Docker Context for Buildx
         id: buildx-context
@@ -69,11 +76,11 @@ jobs:
           username: ${{ secrets.JFROG_FLOWCODE_FC_DOCKER_USERNAME }}
           password: ${{ secrets.JFROG_FLOWCODE_FC_DOCKER_PASSWORD }}
       -
-        # Node is required -- is it already provided on our machines or is it necessary to set it up as a step?
+        # Node.js install is required
         name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 'lts/*'
+          node-version: '16'
       -
         # This step does the github release and github tag.
         # It also outputs the tag so that subsequent steps can use it.


### PR DESCRIPTION
### Summary

In the case where there are many commits that need to go out and we want a phased rollout we want to support targeting a specific commit SHA to release from. This will enable passing it in. The default is the same as the actions/checkout default so there will be no change:

```
    # The branch, tag or SHA to checkout. When checking out the repository that
    # triggered a workflow, this defaults to the reference or SHA for that event.
    # Otherwise, uses the default branch.
    ref: ''
```

Any participating repos will need to update there workflow_dispatch command to include the input and pass it through:

```
  workflow_dispatch:
     inputs:
       release-ref:
         required: false
         type: string
         default: ''
         description: "The branch, tag or SHA to checkout"
```

Like this -> https://github.com/dtx-company/flowpages-api/pull/1085