### PR TITLE
chore: moving docker build usage over to legacy ahead of migration

### DIFF
--- a/.github/workflows/build-and-tag-and-prod-release.yaml
+++ b/.github/workflows/build-and-tag-and-prod-release.yaml
@@ -73,7 +73,7 @@ jobs:
         id: semantic-release
         uses: dtx-company/shared-github-workflows/composite-actions/release-notes@v1.0.0
       - name: build and push docker
-        uses: dtx-company/shared-github-workflows/composite-actions/docker-build-and-push@v1
+        uses: dtx-company/shared-github-workflows/composite-actions/docker-build-and-push-flow-legacy@v1
         with:
           runner: ${{ inputs.runner }}
           service: ${{ inputs.service }}


### PR DESCRIPTION
These two actions are identical : 

```
diff docker-build-and-push/action.yaml docker-build-and-push-flow-legacy/action.yaml
1c1
< name: docker-build-and-push
---
> name: docker-build-and-push-flow-legacy
```

Moving so that we can have the `docker-build-and-push` be updated to be reusable