### PR TITLE
Fix: use flow environment secrets

### DIFF
--- a/.github/workflows/build-and-push-and-deploy-flow-preprod.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow-preprod.yaml
@@ -1,5 +1,7 @@
 name: build-and-push-and-deploy-flow
 
+# Releases the flow app to preprod
+
 on:
   workflow_call:
     inputs:
@@ -22,11 +24,6 @@ on:
         type: string
         description: "comma separated list of clusters to release to, defaults to 'primary'"
         default: "primary"
-      environment:
-        required: false
-        type: string
-        description: "GitHub environment from the 'flow' repository to source environment secrets from"
-        default: "reviewapp"
       extra-deployments:
         required: false
         description: "for services that have multiple deployments in their values.yaml in fc-infra-kubernetes, provide the names of the other deployments e.g. 'worker,beat' as a comma separated list"
@@ -64,11 +61,11 @@ on:
       JFROG_FLOWCODE_FC_PYPI_PASSWORD:
         required: false
       ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER:
-        required: false
+        required: true
       ECR_FLOWCODE_SDLC_FC_DOCKER_KEY:
-        required: false
+        required: true
       ECR_FLOWCODE_SDLC_FC_DOCKER_SECRET:
-        required: false
+        required: true
       BUF_CICD_USER:
         required: false
       BUF_CICD_TOKEN:
@@ -102,20 +99,15 @@ permissions:
 jobs:
   cd:
     runs-on: [self-hosted, "${{ inputs.runner }}"]
-    environment:
-      name: ${{ inputs.environment }}
-    env:
-      ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ inputs.environment == 'prod' && secrets.ECR_FLOWCODE_PROD_FC_DOCKER_SERVER || secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
-      ECR_FLOWCODE_FC_DOCKER_KEY: ${{ inputs.environment == 'prod' && secrets.ECR_FLOWCODE_PROD_FC_DOCKER_KEY || secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_KEY }}
-      ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ inputs.environment == 'prod' && secrets.ECR_FLOWCODE_PROD_FC_DOCKER_SECRET || secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SECRET }}
+    environment: preprod
     steps:
       - name: Setup Image Repository
         uses: dtx-company/shared-github-workflows/composite-actions/setup-image-repository@v1
         with:
           service: ${{ inputs.service }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
-          ECR_FLOWCODE_FC_DOCKER_KEY: ${{ env.ECR_FLOWCODE_FC_DOCKER_KEY }}
-          ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ env.ECR_FLOWCODE_FC_DOCKER_SECRET }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_KEY: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SECRET }}
       - name: Setup Docker
         uses: dtx-company/shared-github-workflows/composite-actions/setup-docker@v1
       - name: Docker Build and Push
@@ -136,30 +128,16 @@ jobs:
             STRIPE_API_KEY=${{ secrets.STRIPE_API_KEY }}
             STRIPE_FLOW_STARTER_CHECKOUT_KEY=${{ secrets.STRIPE_FLOW_STARTER_CHECKOUT_KEY }}
             STRIPE_PRINT_STORE_CHECKOUT_KEY=${{ secrets.STRIPE_PRINT_STORE_CHECKOUT_KEY }}
-          ecr-image-path : ${{ inputs.ecr-image-path }}
+          ecr-image-path: ${{ inputs.ecr-image-path }}
           PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
           JFROG_FLOWCODE_FC_PYPI_USERNAME: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_USERNAME }}
           JFROG_FLOWCODE_FC_PYPI_PASSWORD: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_PASSWORD }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
           BUF_CICD_USER: ${{ secrets.BUF_CICD_USER }}
           BUF_CICD_TOKEN: ${{ secrets.BUF_CICD_TOKEN }}
           GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID }}
           GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
-      - name: Extract flow-app assets for staging
-        # Staging assets have their own bucket
-        if: inputs.post-build-script != '' && inputs.environment == 'stg'
-        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
-        with:
-          service: ${{ inputs.service }}
-          image-tag: ${{ github.sha }}
-          ecr-image-path: ${{ inputs.ecr-image-path }}
-          post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
-          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
-          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
       - name: Extract flow-app assets for preprod
-        # Preprod assets have their own bucket
-        if: inputs.post-build-script != '' && inputs.environment == 'preprod'
         uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
         with:
           service: ${{ inputs.service }}
@@ -168,19 +146,7 @@ jobs:
           post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
           STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.PREPROD_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
           STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.PREPROD_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
-      - name: Extract flow-app assets for prod
-        # Prod assets have their own bucket
-        if: inputs.post-build-script != '' && inputs.environment == 'prod'
-        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
-        with:
-          service: ${{ inputs.service }}
-          image-tag: ${{ github.sha }}
-          ecr-image-path: ${{ inputs.ecr-image-path }}
-          post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
-          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.PROD_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
-          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
       - name: Update fc-infra-kubernetes
         uses: dtx-company/shared-github-workflows/composite-actions/update-infra-kubernetes@v1
         with:
@@ -192,4 +158,4 @@ jobs:
           clusters: ${{ inputs.clusters }}
           ecr-image-path: ${{ inputs.ecr-image-path }}
           PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}

--- a/.github/workflows/build-and-push-and-deploy-flow-prod.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow-prod.yaml
@@ -1,0 +1,165 @@
+name: build-and-push-and-deploy-flow
+
+# Releases the flow app to production
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: false
+        type: string
+        default: "fc-general"
+        description: "the self-hosted github runner to run on, options are {fc-general, frontend, fc-node, fc-go}"
+      service:
+        required: true
+        type: string
+      project:
+        required: true
+        type: string
+      image-tag:
+        required: false
+        type: string
+      clusters:
+        required: false
+        type: string
+        description: "comma separated list of clusters to release to, defaults to 'primary'"
+        default: "primary"
+      extra-deployments:
+        required: false
+        description: "for services that have multiple deployments in their values.yaml in fc-infra-kubernetes, provide the names of the other deployments e.g. 'worker,beat' as a comma separated list"
+        type: string
+      dockerfilepath:
+        required: false
+        type: string
+        default: "./Dockerfile" # Dockerfile in the root of the repo
+      docker-build-args:
+        required: false
+        type: string
+        description: "newline separated list of non-secret arguments to pass to the docker build, e.g. 'APP_ENV=stg\nFOO=foo'"
+      awsenvs:
+        required: false
+        description: "comma separated list of envs to release to, defaults to 'fc-services-stg/use1,fc-services-preprod/use1'"
+        type: string
+        default: "fc-services-stg/use1,fc-services-preprod/use1"
+      post-build-script:
+        required: false
+        description: "file path of a shell script to run between the build step and the release step, e.g. 'scripts/myscript.sh'"
+        type: string
+      post-build-script-inputs:
+        required: false
+        description: "json string to pass to the post-build-script"
+        type: string
+      ecr-image-path:
+        required: false
+        description: "custom path to access the ECR docker image"
+        type: string
+    secrets:
+      PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
+        required: false
+      JFROG_FLOWCODE_FC_PYPI_USERNAME:
+        required: false
+      JFROG_FLOWCODE_FC_PYPI_PASSWORD:
+        required: false
+      ECR_FLOWCODE_PROD_FC_DOCKER_SERVER:
+        required: true
+      ECR_FLOWCODE_PROD_FC_DOCKER_KEY:
+        required: true
+      ECR_FLOWCODE_PROD_FC_DOCKER_SECRET:
+        required: true
+      BUF_CICD_USER:
+        required: false
+      BUF_CICD_TOKEN:
+        required: false
+      GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID:
+        required: false
+      GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY:
+        required: false
+      FLOWLYTICS_FC_GEOGRAPHY_CHART:
+        required: false
+      GENERATOR_CACHE_REDIS_PASSWORD:
+        required: false
+      GOOGLE_CLOUD_API_KEY:
+        required: false
+      OPENSEA_API_KEY:
+        required: false
+      OPTIMIZELY_SDK_KEY:
+        required: false
+      RECAPTCHA_SITE_KEY:
+        required: false
+      STRIPE_API_KEY:
+        required: false
+      STRIPE_FLOW_STARTER_CHECKOUT_KEY:
+        required: false
+      STRIPE_PRINT_STORE_CHECKOUT_KEY:
+        required: false
+      PROD_STATIC_ASSETS_AWS_ACCESS_KEY_ID:
+        required: true
+      PROD_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY:
+        required: true
+
+permissions:
+  id-token: write # Required for aws role assumption
+
+jobs:
+  cd:
+    runs-on: [self-hosted, "${{ inputs.runner }}"]
+    environment: prod
+    steps:
+      - name: Setup Image Repository
+        uses: dtx-company/shared-github-workflows/composite-actions/setup-image-repository@v1
+        with:
+          service: ${{ inputs.service }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_PROD_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_KEY: ${{ secrets.ECR_FLOWCODE_PROD_FC_DOCKER_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ secrets.ECR_FLOWCODE_PROD_FC_DOCKER_SECRET }}
+      - name: Setup Docker
+        uses: dtx-company/shared-github-workflows/composite-actions/setup-docker@v1
+      - name: Docker Build and Push
+        uses: dtx-company/shared-github-workflows/composite-actions/docker-build-and-push-flow@v1
+        with:
+          service: ${{ inputs.service }}
+          image-tag: ${{ github.sha }}
+          branch-name: ${{ github.head_ref || github.ref_name }}
+          dockerfilepath: ${{ inputs.dockerfilepath }}
+          docker-build-args: |
+            ${{ inputs.docker-build-args }}
+            FLOWLYTICS_FC_GEOGRAPHY_CHART=${{ secrets.FLOWLYTICS_FC_GEOGRAPHY_CHART }}
+            GENERATOR_CACHE_REDIS_PASSWORD=${{ secrets.GENERATOR_CACHE_REDIS_PASSWORD }}
+            GOOGLE_CLOUD_API_KEY=${{ secrets.GOOGLE_CLOUD_API_KEY }}
+            OPENSEA_API_KEY=${{ secrets.OPENSEA_API_KEY }}
+            OPTIMIZELY_SDK_KEY=${{ secrets.OPTIMIZELY_SDK_KEY }}
+            RECAPTCHA_SITE_KEY=${{ secrets.RECAPTCHA_SITE_KEY }}
+            STRIPE_API_KEY=${{ secrets.STRIPE_API_KEY }}
+            STRIPE_FLOW_STARTER_CHECKOUT_KEY=${{ secrets.STRIPE_FLOW_STARTER_CHECKOUT_KEY }}
+            STRIPE_PRINT_STORE_CHECKOUT_KEY=${{ secrets.STRIPE_PRINT_STORE_CHECKOUT_KEY }}
+          ecr-image-path: ${{ inputs.ecr-image-path }}
+          PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+          JFROG_FLOWCODE_FC_PYPI_USERNAME: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_USERNAME }}
+          JFROG_FLOWCODE_FC_PYPI_PASSWORD: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_PASSWORD }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_PROD_FC_DOCKER_SERVER }}
+          BUF_CICD_USER: ${{ secrets.BUF_CICD_USER }}
+          BUF_CICD_TOKEN: ${{ secrets.BUF_CICD_TOKEN }}
+          GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID }}
+          GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
+      - name: Extract flow-app assets
+        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
+        with:
+          service: ${{ inputs.service }}
+          image-tag: ${{ github.sha }}
+          ecr-image-path: ${{ inputs.ecr-image-path }}
+          post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
+          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.PROD_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
+          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_PROD_FC_DOCKER_SERVER }}
+      - name: Update fc-infra-kubernetes
+        uses: dtx-company/shared-github-workflows/composite-actions/update-infra-kubernetes@v1
+        with:
+          service: ${{ inputs.service }}
+          project: ${{ inputs.project }}
+          awsenvs: ${{ inputs.awsenvs }}
+          extra-deployments: ${{ inputs.extra-deployments }}
+          image-tag: ${{ github.sha }}
+          clusters: ${{ inputs.clusters }}
+          ecr-image-path: ${{ inputs.ecr-image-path }}
+          PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_PROD_FC_DOCKER_SERVER }}

--- a/.github/workflows/build-and-push-and-deploy-flow-stg.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow-stg.yaml
@@ -1,0 +1,161 @@
+name: build-and-push-and-deploy-flow
+
+# Releases the flow app to staging
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: false
+        type: string
+        default: "fc-general"
+        description: "the self-hosted github runner to run on, options are {fc-general, frontend, fc-node, fc-go}"
+      service:
+        required: true
+        type: string
+      project:
+        required: true
+        type: string
+      image-tag:
+        required: false
+        type: string
+      clusters:
+        required: false
+        type: string
+        description: "comma separated list of clusters to release to, defaults to 'primary'"
+        default: "primary"
+      extra-deployments:
+        required: false
+        description: "for services that have multiple deployments in their values.yaml in fc-infra-kubernetes, provide the names of the other deployments e.g. 'worker,beat' as a comma separated list"
+        type: string
+      dockerfilepath:
+        required: false
+        type: string
+        default: "./Dockerfile" # Dockerfile in the root of the repo
+      docker-build-args:
+        required: false
+        type: string
+        description: "newline separated list of non-secret arguments to pass to the docker build, e.g. 'APP_ENV=stg\nFOO=foo'"
+      awsenvs:
+        required: false
+        description: "comma separated list of envs to release to, defaults to 'fc-services-stg/use1,fc-services-preprod/use1'"
+        type: string
+        default: "fc-services-stg/use1,fc-services-preprod/use1"
+      post-build-script:
+        required: false
+        description: "file path of a shell script to run between the build step and the release step, e.g. 'scripts/myscript.sh'"
+        type: string
+      post-build-script-inputs:
+        required: false
+        description: "json string to pass to the post-build-script"
+        type: string
+      ecr-image-path:
+        required: false
+        description: "custom path to access the ECR docker image"
+        type: string
+    secrets:
+      PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
+        required: false
+      JFROG_FLOWCODE_FC_PYPI_USERNAME:
+        required: false
+      JFROG_FLOWCODE_FC_PYPI_PASSWORD:
+        required: false
+      ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER:
+        required: true
+      ECR_FLOWCODE_SDLC_FC_DOCKER_KEY:
+        required: true
+      ECR_FLOWCODE_SDLC_FC_DOCKER_SECRET:
+        required: true
+      BUF_CICD_USER:
+        required: false
+      BUF_CICD_TOKEN:
+        required: false
+      GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID:
+        required: false
+      GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY:
+        required: false
+      FLOWLYTICS_FC_GEOGRAPHY_CHART:
+        required: false
+      GENERATOR_CACHE_REDIS_PASSWORD:
+        required: false
+      GOOGLE_CLOUD_API_KEY:
+        required: false
+      OPENSEA_API_KEY:
+        required: false
+      OPTIMIZELY_SDK_KEY:
+        required: false
+      RECAPTCHA_SITE_KEY:
+        required: false
+      STRIPE_API_KEY:
+        required: false
+      STRIPE_FLOW_STARTER_CHECKOUT_KEY:
+        required: false
+      STRIPE_PRINT_STORE_CHECKOUT_KEY:
+        required: false
+
+permissions:
+  id-token: write # Required for aws role assumption
+
+jobs:
+  cd:
+    runs-on: [self-hosted, "${{ inputs.runner }}"]
+    environment: stg
+    steps:
+      - name: Setup Image Repository
+        uses: dtx-company/shared-github-workflows/composite-actions/setup-image-repository@v1
+        with:
+          service: ${{ inputs.service }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_KEY: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SECRET }}
+      - name: Setup Docker
+        uses: dtx-company/shared-github-workflows/composite-actions/setup-docker@v1
+      - name: Docker Build and Push
+        uses: dtx-company/shared-github-workflows/composite-actions/docker-build-and-push-flow@fix/flow-app-secrets # TODO: Move back to v1 after testing
+        with:
+          service: ${{ inputs.service }}
+          image-tag: ${{ github.sha }}
+          branch-name: ${{ github.head_ref || github.ref_name }}
+          dockerfilepath: ${{ inputs.dockerfilepath }}
+          docker-build-args: |
+            ${{ inputs.docker-build-args }}
+            FLOWLYTICS_FC_GEOGRAPHY_CHART=${{ secrets.FLOWLYTICS_FC_GEOGRAPHY_CHART }}
+            GENERATOR_CACHE_REDIS_PASSWORD=${{ secrets.GENERATOR_CACHE_REDIS_PASSWORD }}
+            GOOGLE_CLOUD_API_KEY=${{ secrets.GOOGLE_CLOUD_API_KEY }}
+            OPENSEA_API_KEY=${{ secrets.OPENSEA_API_KEY }}
+            OPTIMIZELY_SDK_KEY=${{ secrets.OPTIMIZELY_SDK_KEY }}
+            RECAPTCHA_SITE_KEY=${{ secrets.RECAPTCHA_SITE_KEY }}
+            STRIPE_API_KEY=${{ secrets.STRIPE_API_KEY }}
+            STRIPE_FLOW_STARTER_CHECKOUT_KEY=${{ secrets.STRIPE_FLOW_STARTER_CHECKOUT_KEY }}
+            STRIPE_PRINT_STORE_CHECKOUT_KEY=${{ secrets.STRIPE_PRINT_STORE_CHECKOUT_KEY }}
+          ecr-image-path: ${{ inputs.ecr-image-path }}
+          PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+          JFROG_FLOWCODE_FC_PYPI_USERNAME: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_USERNAME }}
+          JFROG_FLOWCODE_FC_PYPI_PASSWORD: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_PASSWORD }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
+          BUF_CICD_USER: ${{ secrets.BUF_CICD_USER }}
+          BUF_CICD_TOKEN: ${{ secrets.BUF_CICD_TOKEN }}
+          GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID }}
+          GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
+      - name: Extract flow-app assets
+        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
+        with:
+          service: ${{ inputs.service }}
+          image-tag: ${{ github.sha }}
+          ecr-image-path: ${{ inputs.ecr-image-path }}
+          post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
+          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
+          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
+      - name: Update fc-infra-kubernetes
+        uses: dtx-company/shared-github-workflows/composite-actions/update-infra-kubernetes@v1
+        with:
+          service: ${{ inputs.service }}
+          project: ${{ inputs.project }}
+          awsenvs: ${{ inputs.awsenvs }}
+          extra-deployments: ${{ inputs.extra-deployments }}
+          image-tag: ${{ github.sha }}
+          clusters: ${{ inputs.clusters }}
+          ecr-image-path: ${{ inputs.ecr-image-path }}
+          PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}

--- a/.github/workflows/build-and-push-and-deploy-flow-stg.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow-stg.yaml
@@ -99,7 +99,7 @@ permissions:
 jobs:
   cd:
     runs-on: [self-hosted, "${{ inputs.runner }}"]
-    environment: stg
+    environment: reviewapp # TODO: Move back to `stg` after testing
     steps:
       - name: Setup Image Repository
         uses: dtx-company/shared-github-workflows/composite-actions/setup-image-repository@v1

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -109,9 +109,6 @@ jobs:
       ECR_FLOWCODE_FC_DOCKER_KEY: ${{ inputs.environment == 'prod' && secrets.ECR_FLOWCODE_PROD_FC_DOCKER_KEY || secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_KEY }}
       ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ inputs.environment == 'prod' && secrets.ECR_FLOWCODE_PROD_FC_DOCKER_SECRET || secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SECRET }}
     steps:
-      - name: Fail fast # TODO: Take this out later
-        if: inputs.environment == 'prod'
-        run: exit 1
       - name: Setup Image Repository
         uses: dtx-company/shared-github-workflows/composite-actions/setup-image-repository@v1
         with:
@@ -122,7 +119,7 @@ jobs:
       - name: Setup Docker
         uses: dtx-company/shared-github-workflows/composite-actions/setup-docker@v1
       - name: Docker Build and Push
-        uses: dtx-company/shared-github-workflows/composite-actions/docker-build-and-push-flow@fix/flow-app-secrets
+        uses: dtx-company/shared-github-workflows/composite-actions/docker-build-and-push-flow@v1
         with:
           service: ${{ inputs.service }}
           image-tag: ${{ github.sha }}
@@ -150,7 +147,7 @@ jobs:
           GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
       - name: Extract flow-app assets for staging
         # Staging assets have their own bucket
-        if: inputs.post-build-script != '' && inputs.environment == 'reviewapp' # TODO: Change this to stg
+        if: inputs.post-build-script != '' && inputs.environment == 'stg'
         uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
         with:
           service: ${{ inputs.service }}

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -148,21 +148,21 @@ jobs:
           BUF_CICD_TOKEN: ${{ secrets.BUF_CICD_TOKEN }}
           GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID }}
           GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
-      - name: Extract flow-app assets for staging
-        # Staging assets have their own bucket
-        if: inputs.post-build-script != '' && inputs.environment == 'reviewapp' # TODO: Change this to stg
-        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
-        with:
-          service: ${{ inputs.service }}
-          image-tag: ${{ github.sha }}
-          ecr-image-path: ${{ inputs.ecr-image-path }}
-          post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
-          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
-          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+      # - name: Extract flow-app assets for staging
+      #   # Staging assets have their own bucket
+      #   if: inputs.post-build-script != '' && inputs.environment == 'reviewapp' # TODO: Change this to stg
+      #   uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
+      #   with:
+      #     service: ${{ inputs.service }}
+      #     image-tag: ${{ github.sha }}
+      #     ecr-image-path: ${{ inputs.ecr-image-path }}
+      #     post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
+      #     STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
+      #     STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
+      #     ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
       - name: Extract flow-app assets for preprod
         # Preprod assets have their own bucket
-        if: inputs.post-build-script != '' && inputs.environment == 'preprod'
+        # if: inputs.post-build-script != '' && inputs.environment == 'preprod'
         uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
         with:
           service: ${{ inputs.service }}
@@ -172,18 +172,18 @@ jobs:
           STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.PREPROD_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
           STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.PREPROD_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
           ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
-      - name: Extract flow-app assets for prod
-        # Prod assets have their own bucket
-        if: inputs.post-build-script != '' && inputs.environment == 'prod'
-        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
-        with:
-          service: ${{ inputs.service }}
-          image-tag: ${{ github.sha }}
-          ecr-image-path: ${{ inputs.ecr-image-path }}
-          post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
-          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.PROD_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
-          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+      # - name: Extract flow-app assets for prod
+      #   # Prod assets have their own bucket
+      #   if: inputs.post-build-script != '' && inputs.environment == 'prod'
+      #   uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
+      #   with:
+      #     service: ${{ inputs.service }}
+      #     image-tag: ${{ github.sha }}
+      #     ecr-image-path: ${{ inputs.ecr-image-path }}
+      #     post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
+      #     STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.PROD_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
+      #     STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
+      #     ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
       - name: Update fc-infra-kubernetes
         uses: dtx-company/shared-github-workflows/composite-actions/update-infra-kubernetes@v1
         with:

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -77,9 +77,9 @@ on:
         required: false
       BUF_CICD_TOKEN:
         required: false
-      BUILD_ARTIFACTS_S3_CACHE_AWS_ACCESS_KEY_ID:
+      GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID:
         required: false
-      BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY:
+      GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY:
         required: false
       FLOWLYTICS_FC_GEOGRAPHY_CHART:
         required: false
@@ -108,36 +108,16 @@ jobs:
     runs-on: [self-hosted, "${{ inputs.runner }}"]
     environment:
       name: ${{ inputs.environment }}
-    env:
-      # Creds come from Parameter Store `/fc/frontend/application/githubactions-flow/service-accounts/aws/fc-frontend-global-stg-githubactions-flow`
-      STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
-      STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
-      ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
-      ECR_FLOWCODE_FC_DOCKER_KEY: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_KEY }}
-      ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SECRET }}
-      BUILD_ARTIFACTS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID }}
-      BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY }} 
-      FLOWLYTICS_FC_GEOGRAPHY_CHART: ${{ secrets.FLOWLYTICS_FC_GEOGRAPHY_CHART }}
-      GENERATOR_CACHE_REDIS_PASSWORD: ${{ secrets.GENERATOR_CACHE_REDIS_PASSWORD }}
-      GOOGLE_CLOUD_API_KEY: ${{ secrets.GOOGLE_CLOUD_API_KEY }}
-      OPENSEA_API_KEY: ${{ secrets.OPENSEA_API_KEY }}
-      OPTIMIZELY_SDK_KEY: ${{ secrets.OPTIMIZELY_SDK_KEY }}
-      RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
-      STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
-      STRIPE_FLOW_STARTER_CHECKOUT_KEY: ${{ secrets.STRIPE_FLOW_STARTER_CHECKOUT_KEY }}
-      STRIPE_PRINT_STORE_CHECKOUT_KEY: ${{ secrets.STRIPE_PRINT_STORE_CHECKOUT_KEY }}
     steps:
       - name: Setup Image Repository
         uses: dtx-company/shared-github-workflows/composite-actions/setup-image-repository@v1
         with:
           service: ${{ inputs.service }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
-          ECR_FLOWCODE_FC_DOCKER_KEY: ${{ env.ECR_FLOWCODE_FC_DOCKER_KEY }}
-          ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ env.ECR_FLOWCODE_FC_DOCKER_SECRET }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_KEY: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SECRET }}
       - name: Setup Docker
         uses: dtx-company/shared-github-workflows/composite-actions/setup-docker@v1
-      - name: Test
-        run: echo ${{ inputs.environment }}
       - name: Docker Build and Push
         uses: dtx-company/shared-github-workflows/composite-actions/docker-build-and-push-flow@fix/flow-app-secrets
         with:
@@ -153,18 +133,18 @@ jobs:
             OPENSEA_API_KEY=${{ secrets.OPENSEA_API_KEY }}
             OPTIMIZELY_SDK_KEY=${{ secrets.OPTIMIZELY_SDK_KEY }}
             RECAPTCHA_SITE_KEY=${{ secrets.RECAPTCHA_SITE_KEY }}
-            STRIPE_API_KEY=${{ env.STRIPE_API_KEY }}
+            STRIPE_API_KEY=${{ secrets.STRIPE_API_KEY }}
             STRIPE_FLOW_STARTER_CHECKOUT_KEY=${{ secrets.STRIPE_FLOW_STARTER_CHECKOUT_KEY }}
             STRIPE_PRINT_STORE_CHECKOUT_KEY=${{ secrets.STRIPE_PRINT_STORE_CHECKOUT_KEY }}
           ecr-image-path : ${{ inputs.ecr-image-path }}
           PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
           JFROG_FLOWCODE_FC_PYPI_USERNAME: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_USERNAME }}
           JFROG_FLOWCODE_FC_PYPI_PASSWORD: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_PASSWORD }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
           BUF_CICD_USER: ${{ secrets.BUF_CICD_USER }}
           BUF_CICD_TOKEN: ${{ secrets.BUF_CICD_TOKEN }}
-          GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ env.BUILD_ARTIFACTS_S3_CACHE_AWS_ACCESS_KEY_ID }}
-          GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ env.BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
+          GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID }}
+          GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
       - name: Extract flow-app assets
         if: inputs.post-build-script != ''
         uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
@@ -173,9 +153,9 @@ jobs:
           image-tag: ${{ github.sha }}
           ecr-image-path: ${{ inputs.ecr-image-path }}
           post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
-          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ env.STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID }}
-          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ env.STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID }}
+          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
       - name: Update fc-infra-kubernetes
         uses: dtx-company/shared-github-workflows/composite-actions/update-infra-kubernetes@v1
         with:
@@ -187,4 +167,4 @@ jobs:
           clusters: ${{ inputs.clusters }}
           ecr-image-path: ${{ inputs.ecr-image-path }}
           PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -96,9 +96,6 @@ on:
       STRIPE_PRINT_STORE_CHECKOUT_KEY:
         required: false
 
-# ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
-# ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
-
 permissions:
   id-token: write # Required for aws role assumption
 
@@ -107,14 +104,21 @@ jobs:
     runs-on: [self-hosted, "${{ inputs.runner }}"]
     environment:
       name: ${{ inputs.environment }}
+    env:
+      ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ inputs.environment == 'prod' && secrets.ECR_FLOWCODE_PROD_FC_DOCKER_SERVER || secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
+      ECR_FLOWCODE_FC_DOCKER_KEY: ${{ inputs.environment == 'prod' && secrets.ECR_FLOWCODE_PROD_FC_DOCKER_KEY || secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_KEY }}
+      ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ inputs.environment == 'prod' && secrets.ECR_FLOWCODE_PROD_FC_DOCKER_SECRET || secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SECRET }}
     steps:
+      - name: Fail fast # TODO: Take this out later
+        if: inputs.environment == 'prod'
+        run: exit 1
       - name: Setup Image Repository
         uses: dtx-company/shared-github-workflows/composite-actions/setup-image-repository@v1
         with:
           service: ${{ inputs.service }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
-          ECR_FLOWCODE_FC_DOCKER_KEY: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_KEY }}
-          ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SECRET }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_KEY: ${{ env.ECR_FLOWCODE_FC_DOCKER_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ env.ECR_FLOWCODE_FC_DOCKER_SECRET }}
       - name: Setup Docker
         uses: dtx-company/shared-github-workflows/composite-actions/setup-docker@v1
       - name: Docker Build and Push
@@ -139,12 +143,13 @@ jobs:
           PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
           JFROG_FLOWCODE_FC_PYPI_USERNAME: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_USERNAME }}
           JFROG_FLOWCODE_FC_PYPI_PASSWORD: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_PASSWORD }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
           BUF_CICD_USER: ${{ secrets.BUF_CICD_USER }}
           BUF_CICD_TOKEN: ${{ secrets.BUF_CICD_TOKEN }}
           GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID }}
           GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
       - name: Extract flow-app assets for staging
+        # Staging assets have their own bucket
         if: inputs.post-build-script != '' && inputs.environment == 'reviewapp' # TODO: Change this to stg
         uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
         with:
@@ -154,7 +159,31 @@ jobs:
           post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
           STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
           STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+      - name: Extract flow-app assets for preprod
+        # Preprod assets have their own bucket
+        if: inputs.post-build-script != '' && inputs.environment == 'preprod'
+        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
+        with:
+          service: ${{ inputs.service }}
+          image-tag: ${{ github.sha }}
+          ecr-image-path: ${{ inputs.ecr-image-path }}
+          post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
+          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.PREPROD_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
+          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.PREPROD_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+      - name: Extract flow-app assets for prod
+        # Prod assets have their own bucket
+        if: inputs.post-build-script != '' && inputs.environment == 'prod'
+        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
+        with:
+          service: ${{ inputs.service }}
+          image-tag: ${{ github.sha }}
+          ecr-image-path: ${{ inputs.ecr-image-path }}
+          post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
+          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.PROD_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
+          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
       - name: Update fc-infra-kubernetes
         uses: dtx-company/shared-github-workflows/composite-actions/update-infra-kubernetes@v1
         with:
@@ -166,4 +195,4 @@ jobs:
           clusters: ${{ inputs.clusters }}
           ecr-image-path: ${{ inputs.ecr-image-path }}
           PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -1,0 +1,135 @@
+name: build-and-push-and-deploy-flow
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: false
+        type: string
+        default: "fc-general"
+        description: "the self-hosted github runner to run on, options are {fc-general, frontend, fc-node, fc-go}"
+      service:
+        required: true
+        type: string
+      project:
+        required: true
+        type: string
+      image-tag:
+        required: false
+        type: string
+      clusters:
+        required: false
+        type: string
+        description: "comma separated list of clusters to release to, defaults to 'primary'"
+        default: "primary"
+      extra-deployments:
+        required: false
+        description: "for services that have multiple deployments in their values.yaml in fc-infra-kubernetes, provide the names of the other deployments e.g. 'worker,beat' as a comma separated list"
+        type: string
+      dockerfilepath:
+        required: false
+        type: string
+        default: "./Dockerfile" # Dockerfile in the root of the repo
+      docker-build-args:
+        required: false
+        type: string
+        description: "newline separated list of non-secret arguments to pass to the docker build, e.g. 'APP_ENV=stg\nFOO=foo'"
+      awsenvs:
+        required: false
+        description: "comma separated list of envs to release to, defaults to 'fc-services-stg/use1,fc-services-preprod/use1'"
+        type: string
+        default: "fc-services-stg/use1,fc-services-preprod/use1"
+      post-build-script:
+        required: false
+        description: "file path of a shell script to run between the build step and the release step, e.g. 'scripts/myscript.sh'"
+        type: string
+      post-build-script-inputs:
+        required: false
+        description: "json string to pass to the post-build-script"
+        type: string
+      ecr-image-path:
+        required: false
+        description: "custom path to access the ECR docker image"
+        type: string
+    secrets:
+      PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
+        required: true
+      JFROG_FLOWCODE_FC_PYPI_USERNAME:
+        required: false
+      JFROG_FLOWCODE_FC_PYPI_PASSWORD:
+        required: false
+      STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID:
+        required: false
+      STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY:
+        required: false
+      ECR_FLOWCODE_FC_DOCKER_SERVER:
+        required: true
+      ECR_FLOWCODE_FC_DOCKER_KEY:
+        required: true
+      ECR_FLOWCODE_FC_DOCKER_SECRET:
+        required: true
+      BUF_CICD_USER:
+        required: false
+      BUF_CICD_TOKEN:
+        required: false
+      BUILD_ARTIFACTS_S3_CACHE_AWS_ACCESS_KEY_ID:
+        required: false
+      BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY:
+        required: false
+
+permissions:
+  id-token: write # Required for aws role assumption
+
+jobs:
+  cd:
+    runs-on: [self-hosted, "${{ inputs.runner }}"]
+    steps:
+      - name: Setup Image Repository
+        uses: dtx-company/shared-github-workflows/composite-actions/setup-image-repository@v1
+        with:
+          service: ${{ inputs.service }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_KEY: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SECRET }}
+      - name: Setup Docker
+        uses: dtx-company/shared-github-workflows/composite-actions/setup-docker@v1
+      - name: Docker Build and Push
+        uses: dtx-company/shared-github-workflows/composite-actions/docker-build-and-push-flow@v1
+        with:
+          service: ${{ inputs.service }}
+          image-tag: ${{ github.sha }}
+          branch-name: ${{ github.head_ref || github.ref_name }}
+          dockerfilepath: ${{ inputs.dockerfilepath }}
+          docker-build-args: ${{ inputs.docker-build-args }}
+          ecr-image-path: ${{ inputs.ecr-image-path }}
+          PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+          JFROG_FLOWCODE_FC_PYPI_USERNAME: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_USERNAME }}
+          JFROG_FLOWCODE_FC_PYPI_PASSWORD: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_PASSWORD }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          BUF_CICD_USER: ${{ secrets.BUF_CICD_USER }}
+          BUF_CICD_TOKEN: ${{ secrets.BUF_CICD_TOKEN }}
+          GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.BUILD_ARTIFACTS_S3_CACHE_AWS_ACCESS_KEY_ID }}
+          GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
+      - name: Extract flow-app assets
+        if: inputs.post-build-script != ''
+        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
+        with:
+          service: ${{ inputs.service }}
+          image-tag: ${{ github.sha }}
+          ecr-image-path: ${{ inputs.ecr-image-path }}
+          post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
+          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID }}
+          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+      - name: Update fc-infra-kubernetes
+        uses: dtx-company/shared-github-workflows/composite-actions/update-infra-kubernetes@v1
+        with:
+          service: ${{ inputs.service }}
+          project: ${{ inputs.project }}
+          awsenvs: ${{ inputs.awsenvs }}
+          extra-deployments: ${{ inputs.extra-deployments }}
+          image-tag: ${{ github.sha }}
+          clusters: ${{ inputs.clusters }}
+          ecr-image-path: ${{ inputs.ecr-image-path }}
+          PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -81,6 +81,24 @@ on:
         required: false
       BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY:
         required: false
+      FLOWLYTICS_FC_GEOGRAPHY_CHART:
+        required: false
+      GENERATOR_CACHE_REDIS_PASSWORD:
+        required: false
+      GOOGLE_CLOUD_API_KEY:
+        required: false
+      OPENSEA_API_KEY:
+        required: false
+      OPTIMIZELY_SDK_KEY:
+        required: false
+      RECAPTCHA_SITE_KEY:
+        required: false
+      STRIPE_API_KEY:
+        required: false
+      STRIPE_FLOW_STARTER_CHECKOUT_KEY:
+        required: false
+      STRIPE_PRINT_STORE_CHECKOUT_KEY:
+        required: false
 
 permissions:
   id-token: write # Required for aws role assumption

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -108,6 +108,24 @@ jobs:
     runs-on: [self-hosted, "${{ inputs.runner }}"]
     environment:
       name: ${{ inputs.environment }}
+    env:
+      # Creds come from Parameter Store `/fc/frontend/application/githubactions-flow/service-accounts/aws/fc-frontend-global-stg-githubactions-flow`
+      # STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
+      # STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
+      ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
+      # ECR_FLOWCODE_FC_DOCKER_KEY: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_KEY }}
+      # ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SECRET }}
+      # BUILD_ARTIFACTS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID }}
+      # BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY }} 
+      # FLOWLYTICS_FC_GEOGRAPHY_CHART: ${{ secrets.FLOWLYTICS_FC_GEOGRAPHY_CHART }}
+      # GENERATOR_CACHE_REDIS_PASSWORD: ${{ secrets.GENERATOR_CACHE_REDIS_PASSWORD }}
+      # GOOGLE_CLOUD_API_KEY: ${{ secrets.GOOGLE_CLOUD_API_KEY }}
+      # OPENSEA_API_KEY: ${{ secrets.OPENSEA_API_KEY }}
+      # OPTIMIZELY_SDK_KEY: ${{ secrets.OPTIMIZELY_SDK_KEY }}
+      # RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
+      # STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
+      # STRIPE_FLOW_STARTER_CHECKOUT_KEY: ${{ secrets.STRIPE_FLOW_STARTER_CHECKOUT_KEY }}
+      # STRIPE_PRINT_STORE_CHECKOUT_KEY: ${{ secrets.STRIPE_PRINT_STORE_CHECKOUT_KEY }}
     steps:
       - name: Setup Image Repository
         uses: dtx-company/shared-github-workflows/composite-actions/setup-image-repository@v1

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -58,7 +58,7 @@ on:
         type: string
     secrets:
       PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
-        required: true
+        required: false
       JFROG_FLOWCODE_FC_PYPI_USERNAME:
         required: false
       JFROG_FLOWCODE_FC_PYPI_PASSWORD:
@@ -68,11 +68,11 @@ on:
       STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY:
         required: false
       ECR_FLOWCODE_FC_DOCKER_SERVER:
-        required: true
+        required: false
       ECR_FLOWCODE_FC_DOCKER_KEY:
-        required: true
+        required: false
       ECR_FLOWCODE_FC_DOCKER_SECRET:
-        required: true
+        required: false
       BUF_CICD_USER:
         required: false
       BUF_CICD_TOKEN:
@@ -109,6 +109,14 @@ jobs:
     environment:
       name: ${{ inputs.environment }}
     env:
+      # Creds come from Parameter Store `/fc/frontend/application/githubactions-flow/service-accounts/aws/fc-frontend-global-stg-githubactions-flow`
+      STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
+      STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
+      ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
+      ECR_FLOWCODE_FC_DOCKER_KEY: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_KEY }}
+      ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SECRET }}
+      BUILD_ARTIFACTS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID }}
+      BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY }} 
       FLOWLYTICS_FC_GEOGRAPHY_CHART: ${{ secrets.FLOWLYTICS_FC_GEOGRAPHY_CHART }}
       GENERATOR_CACHE_REDIS_PASSWORD: ${{ secrets.GENERATOR_CACHE_REDIS_PASSWORD }}
       GOOGLE_CLOUD_API_KEY: ${{ secrets.GOOGLE_CLOUD_API_KEY }}
@@ -123,9 +131,9 @@ jobs:
         uses: dtx-company/shared-github-workflows/composite-actions/setup-image-repository@v1
         with:
           service: ${{ inputs.service }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
-          ECR_FLOWCODE_FC_DOCKER_KEY: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_KEY }}
-          ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SECRET }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_KEY: ${{ env.ECR_FLOWCODE_FC_DOCKER_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ env.ECR_FLOWCODE_FC_DOCKER_SECRET }}
       - name: Setup Docker
         uses: dtx-company/shared-github-workflows/composite-actions/setup-docker@v1
       - name: Test
@@ -152,11 +160,11 @@ jobs:
           PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
           JFROG_FLOWCODE_FC_PYPI_USERNAME: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_USERNAME }}
           JFROG_FLOWCODE_FC_PYPI_PASSWORD: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_PASSWORD }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
           BUF_CICD_USER: ${{ secrets.BUF_CICD_USER }}
           BUF_CICD_TOKEN: ${{ secrets.BUF_CICD_TOKEN }}
-          GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.BUILD_ARTIFACTS_S3_CACHE_AWS_ACCESS_KEY_ID }}
-          GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
+          GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ env.BUILD_ARTIFACTS_S3_CACHE_AWS_ACCESS_KEY_ID }}
+          GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ env.BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
       - name: Extract flow-app assets
         if: inputs.post-build-script != ''
         uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
@@ -165,9 +173,9 @@ jobs:
           image-tag: ${{ github.sha }}
           ecr-image-path: ${{ inputs.ecr-image-path }}
           post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
-          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID }}
-          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ env.STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID }}
+          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ env.STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
       - name: Update fc-infra-kubernetes
         uses: dtx-company/shared-github-workflows/composite-actions/update-infra-kubernetes@v1
         with:
@@ -179,4 +187,4 @@ jobs:
           clusters: ${{ inputs.clusters }}
           ecr-image-path: ${{ inputs.ecr-image-path }}
           PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -148,21 +148,21 @@ jobs:
           BUF_CICD_TOKEN: ${{ secrets.BUF_CICD_TOKEN }}
           GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID }}
           GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
-      # - name: Extract flow-app assets for staging
-      #   # Staging assets have their own bucket
-      #   if: inputs.post-build-script != '' && inputs.environment == 'reviewapp' # TODO: Change this to stg
-      #   uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
-      #   with:
-      #     service: ${{ inputs.service }}
-      #     image-tag: ${{ github.sha }}
-      #     ecr-image-path: ${{ inputs.ecr-image-path }}
-      #     post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
-      #     STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
-      #     STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
-      #     ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+      - name: Extract flow-app assets for staging
+        # Staging assets have their own bucket
+        if: inputs.post-build-script != '' && inputs.environment == 'reviewapp' # TODO: Change this to stg
+        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
+        with:
+          service: ${{ inputs.service }}
+          image-tag: ${{ github.sha }}
+          ecr-image-path: ${{ inputs.ecr-image-path }}
+          post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
+          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
+          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
       - name: Extract flow-app assets for preprod
         # Preprod assets have their own bucket
-        # if: inputs.post-build-script != '' && inputs.environment == 'preprod'
+        if: inputs.post-build-script != '' && inputs.environment == 'preprod'
         uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
         with:
           service: ${{ inputs.service }}
@@ -172,18 +172,18 @@ jobs:
           STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.PREPROD_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
           STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.PREPROD_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
           ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
-      # - name: Extract flow-app assets for prod
-      #   # Prod assets have their own bucket
-      #   if: inputs.post-build-script != '' && inputs.environment == 'prod'
-      #   uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
-      #   with:
-      #     service: ${{ inputs.service }}
-      #     image-tag: ${{ github.sha }}
-      #     ecr-image-path: ${{ inputs.ecr-image-path }}
-      #     post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
-      #     STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.PROD_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
-      #     STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
-      #     ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+      - name: Extract flow-app assets for prod
+        # Prod assets have their own bucket
+        if: inputs.post-build-script != '' && inputs.environment == 'prod'
+        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
+        with:
+          service: ${{ inputs.service }}
+          image-tag: ${{ github.sha }}
+          ecr-image-path: ${{ inputs.ecr-image-path }}
+          post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
+          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.PROD_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
+          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ env.ECR_FLOWCODE_FC_DOCKER_SERVER }}
       - name: Update fc-infra-kubernetes
         uses: dtx-company/shared-github-workflows/composite-actions/update-infra-kubernetes@v1
         with:

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -99,6 +99,8 @@ jobs:
           ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SECRET }}
       - name: Setup Docker
         uses: dtx-company/shared-github-workflows/composite-actions/setup-docker@v1
+      - name: Test
+        run: echo ${{ inputs.environment }}
       - name: Docker Build and Push
         env:
           FLOWLYTICS_FC_GEOGRAPHY_CHART: ${{ secrets.FLOWLYTICS_FC_GEOGRAPHY_CHART }}

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -102,10 +102,20 @@ on:
       STRIPE_PRINT_STORE_CHECKOUT_KEY:
         required: false
 
+# ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
+# ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
+
 permissions:
   id-token: write # Required for aws role assumption
 
 jobs:
+  set-stg-variables:
+    name: Set staging variables
+    runs-on: [self-hosted, fc-general]
+    if: inputs.environment == 'stg'
+    env:
+      STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
+      STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
   cd:
     runs-on: [self-hosted, "${{ inputs.runner }}"]
     environment:
@@ -155,8 +165,8 @@ jobs:
           image-tag: ${{ github.sha }}
           ecr-image-path: ${{ inputs.ecr-image-path }}
           post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
-          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ inputs.static-assets-aws-access-key-id }}
-          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ inputs.static-assets-aws-secret-access-key }}
+          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ env.STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID }}
+          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ env.STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY }}
           ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
       - name: Update fc-infra-kubernetes
         uses: dtx-company/shared-github-workflows/composite-actions/update-infra-kubernetes@v1

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -22,6 +22,11 @@ on:
         type: string
         description: "comma separated list of clusters to release to, defaults to 'primary'"
         default: "primary"
+      environment:
+        required: false
+        type: string
+        description: "GitHub environment from the 'flow' repository to source environment secrets from"
+        default: "reviewapp"
       extra-deployments:
         required: false
         description: "for services that have multiple deployments in their values.yaml in fc-infra-kubernetes, provide the names of the other deployments e.g. 'worker,beat' as a comma separated list"
@@ -83,6 +88,7 @@ permissions:
 jobs:
   cd:
     runs-on: [self-hosted, "${{ inputs.runner }}"]
+    environment: ${{ inputs.environment }}
     steps:
       - name: Setup Image Repository
         uses: dtx-company/shared-github-workflows/composite-actions/setup-image-repository@v1
@@ -94,13 +100,33 @@ jobs:
       - name: Setup Docker
         uses: dtx-company/shared-github-workflows/composite-actions/setup-docker@v1
       - name: Docker Build and Push
-        uses: dtx-company/shared-github-workflows/composite-actions/docker-build-and-push-flow@v1
+        env:
+          FLOWLYTICS_FC_GEOGRAPHY_CHART: ${{ secrets.FLOWLYTICS_FC_GEOGRAPHY_CHART }}
+          GENERATOR_CACHE_REDIS_PASSWORD: ${{ secrets.GENERATOR_CACHE_REDIS_PASSWORD }}
+          GOOGLE_CLOUD_API_KEY: ${{ secrets.GOOGLE_CLOUD_API_KEY }}
+          OPENSEA_API_KEY: ${{ secrets.OPENSEA_API_KEY }}
+          OPTIMIZELY_SDK_KEY: ${{ secrets.OPTIMIZELY_SDK_KEY }}
+          RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
+          STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
+          STRIPE_FLOW_STARTER_CHECKOUT_KEY: ${{ secrets.STRIPE_FLOW_STARTER_CHECKOUT_KEY }}
+          STRIPE_PRINT_STORE_CHECKOUT_KEY: ${{ secrets.STRIPE_PRINT_STORE_CHECKOUT_KEY }}
+        uses: dtx-company/shared-github-workflows/composite-actions/docker-build-and-push-flow@fix/flow-app-secrets
         with:
           service: ${{ inputs.service }}
           image-tag: ${{ github.sha }}
           branch-name: ${{ github.head_ref || github.ref_name }}
           dockerfilepath: ${{ inputs.dockerfilepath }}
-          docker-build-args: ${{ inputs.docker-build-args }}
+          docker-build-args: |
+            ${{ inputs.docker-build-args }}
+            FLOWLYTICS_FC_GEOGRAPHY_CHART=${{ secrets.FLOWLYTICS_FC_GEOGRAPHY_CHART }}
+            GENERATOR_CACHE_REDIS_PASSWORD=${{ secrets.GENERATOR_CACHE_REDIS_PASSWORD }}
+            GOOGLE_CLOUD_API_KEY=${{ secrets.GOOGLE_CLOUD_API_KEY }}
+            OPENSEA_API_KEY=${{ secrets.OPENSEA_API_KEY }}
+            OPTIMIZELY_SDK_KEY=${{ secrets.OPTIMIZELY_SDK_KEY }}
+            RECAPTCHA_SITE_KEY=${{ secrets.RECAPTCHA_SITE_KEY }}
+            STRIPE_API_KEY=${{ env.STRIPE_API_KEY }}
+            STRIPE_FLOW_STARTER_CHECKOUT_KEY=${{ secrets.STRIPE_FLOW_STARTER_CHECKOUT_KEY }}
+            STRIPE_PRINT_STORE_CHECKOUT_KEY=${{ secrets.STRIPE_PRINT_STORE_CHECKOUT_KEY }}
           ecr-image-path : ${{ inputs.ecr-image-path }}
           PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
           JFROG_FLOWCODE_FC_PYPI_USERNAME: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_USERNAME }}

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -67,11 +67,11 @@ on:
         required: false
       STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY:
         required: false
-      ECR_FLOWCODE_FC_DOCKER_SERVER:
+      ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER:
         required: false
-      ECR_FLOWCODE_FC_DOCKER_KEY:
+      ECR_FLOWCODE_SDLC_FC_DOCKER_KEY:
         required: false
-      ECR_FLOWCODE_FC_DOCKER_SECRET:
+      ECR_FLOWCODE_SDLC_FC_DOCKER_SECRET:
         required: false
       BUF_CICD_USER:
         required: false
@@ -108,32 +108,14 @@ jobs:
     runs-on: [self-hosted, "${{ inputs.runner }}"]
     environment:
       name: ${{ inputs.environment }}
-    env:
-      # Creds come from Parameter Store `/fc/frontend/application/githubactions-flow/service-accounts/aws/fc-frontend-global-stg-githubactions-flow`
-      # STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
-      # STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
-      ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
-      # ECR_FLOWCODE_FC_DOCKER_KEY: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_KEY }}
-      # ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SECRET }}
-      # BUILD_ARTIFACTS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID }}
-      # BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY }} 
-      # FLOWLYTICS_FC_GEOGRAPHY_CHART: ${{ secrets.FLOWLYTICS_FC_GEOGRAPHY_CHART }}
-      # GENERATOR_CACHE_REDIS_PASSWORD: ${{ secrets.GENERATOR_CACHE_REDIS_PASSWORD }}
-      # GOOGLE_CLOUD_API_KEY: ${{ secrets.GOOGLE_CLOUD_API_KEY }}
-      # OPENSEA_API_KEY: ${{ secrets.OPENSEA_API_KEY }}
-      # OPTIMIZELY_SDK_KEY: ${{ secrets.OPTIMIZELY_SDK_KEY }}
-      # RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
-      # STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
-      # STRIPE_FLOW_STARTER_CHECKOUT_KEY: ${{ secrets.STRIPE_FLOW_STARTER_CHECKOUT_KEY }}
-      # STRIPE_PRINT_STORE_CHECKOUT_KEY: ${{ secrets.STRIPE_PRINT_STORE_CHECKOUT_KEY }}
     steps:
       - name: Setup Image Repository
         uses: dtx-company/shared-github-workflows/composite-actions/setup-image-repository@v1
         with:
           service: ${{ inputs.service }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
-          ECR_FLOWCODE_FC_DOCKER_KEY: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_KEY }}
-          ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SECRET }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_KEY: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_KEY }}
+          ECR_FLOWCODE_FC_DOCKER_SECRET: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SECRET }}
       - name: Setup Docker
         uses: dtx-company/shared-github-workflows/composite-actions/setup-docker@v1
       - name: Docker Build and Push
@@ -158,7 +140,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
           JFROG_FLOWCODE_FC_PYPI_USERNAME: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_USERNAME }}
           JFROG_FLOWCODE_FC_PYPI_PASSWORD: ${{ secrets.JFROG_FLOWCODE_FC_PYPI_PASSWORD }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
           BUF_CICD_USER: ${{ secrets.BUF_CICD_USER }}
           BUF_CICD_TOKEN: ${{ secrets.BUF_CICD_TOKEN }}
           GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID }}
@@ -173,7 +155,7 @@ jobs:
           post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
           STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID }}
           STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
       - name: Update fc-infra-kubernetes
         uses: dtx-company/shared-github-workflows/composite-actions/update-infra-kubernetes@v1
         with:
@@ -185,4 +167,4 @@ jobs:
           clusters: ${{ inputs.clusters }}
           ecr-image-path: ${{ inputs.ecr-image-path }}
           PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
-          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -56,12 +56,6 @@ on:
         required: false
         description: "custom path to access the ECR docker image"
         type: string
-      static-assets-aws-access-key-id:
-        required: true
-        type: string
-      static-assets-aws-secret-access-key:
-        required: true
-        type: string
     secrets:
       PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
         required: false
@@ -109,13 +103,6 @@ permissions:
   id-token: write # Required for aws role assumption
 
 jobs:
-  set-stg-variables:
-    name: Set staging variables
-    runs-on: [self-hosted, fc-general]
-    if: inputs.environment == 'stg'
-    env:
-      STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
-      STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
   cd:
     runs-on: [self-hosted, "${{ inputs.runner }}"]
     environment:
@@ -157,16 +144,16 @@ jobs:
           BUF_CICD_TOKEN: ${{ secrets.BUF_CICD_TOKEN }}
           GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_ACCESS_KEY_ID }}
           GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
-      - name: Extract flow-app assets
-        if: inputs.post-build-script != ''
+      - name: Extract flow-app assets for staging
+        if: inputs.post-build-script != '' && inputs.environment == 'reviewapp' # TODO: Change this to stg
         uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
         with:
           service: ${{ inputs.service }}
           image-tag: ${{ github.sha }}
           ecr-image-path: ${{ inputs.ecr-image-path }}
           post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
-          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ env.STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID }}
-          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ env.STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY }}
+          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STG_STATIC_ASSETS_AWS_ACCESS_KEY_ID }}
+          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STG_STATIC_ASSETS_AWS_SECRET_ACCESS_KEY }}
           ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
       - name: Update fc-infra-kubernetes
         uses: dtx-company/shared-github-workflows/composite-actions/update-infra-kubernetes@v1

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -88,7 +88,18 @@ permissions:
 jobs:
   cd:
     runs-on: [self-hosted, "${{ inputs.runner }}"]
-    environment: ${{ inputs.environment }}
+    environment:
+      name: ${{ inputs.environment }}
+    env:
+      FLOWLYTICS_FC_GEOGRAPHY_CHART: ${{ secrets.FLOWLYTICS_FC_GEOGRAPHY_CHART }}
+      GENERATOR_CACHE_REDIS_PASSWORD: ${{ secrets.GENERATOR_CACHE_REDIS_PASSWORD }}
+      GOOGLE_CLOUD_API_KEY: ${{ secrets.GOOGLE_CLOUD_API_KEY }}
+      OPENSEA_API_KEY: ${{ secrets.OPENSEA_API_KEY }}
+      OPTIMIZELY_SDK_KEY: ${{ secrets.OPTIMIZELY_SDK_KEY }}
+      RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
+      STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
+      STRIPE_FLOW_STARTER_CHECKOUT_KEY: ${{ secrets.STRIPE_FLOW_STARTER_CHECKOUT_KEY }}
+      STRIPE_PRINT_STORE_CHECKOUT_KEY: ${{ secrets.STRIPE_PRINT_STORE_CHECKOUT_KEY }}
     steps:
       - name: Setup Image Repository
         uses: dtx-company/shared-github-workflows/composite-actions/setup-image-repository@v1
@@ -102,16 +113,6 @@ jobs:
       - name: Test
         run: echo ${{ inputs.environment }}
       - name: Docker Build and Push
-        env:
-          FLOWLYTICS_FC_GEOGRAPHY_CHART: ${{ secrets.FLOWLYTICS_FC_GEOGRAPHY_CHART }}
-          GENERATOR_CACHE_REDIS_PASSWORD: ${{ secrets.GENERATOR_CACHE_REDIS_PASSWORD }}
-          GOOGLE_CLOUD_API_KEY: ${{ secrets.GOOGLE_CLOUD_API_KEY }}
-          OPENSEA_API_KEY: ${{ secrets.OPENSEA_API_KEY }}
-          OPTIMIZELY_SDK_KEY: ${{ secrets.OPTIMIZELY_SDK_KEY }}
-          RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
-          STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
-          STRIPE_FLOW_STARTER_CHECKOUT_KEY: ${{ secrets.STRIPE_FLOW_STARTER_CHECKOUT_KEY }}
-          STRIPE_PRINT_STORE_CHECKOUT_KEY: ${{ secrets.STRIPE_PRINT_STORE_CHECKOUT_KEY }}
         uses: dtx-company/shared-github-workflows/composite-actions/docker-build-and-push-flow@fix/flow-app-secrets
         with:
           service: ${{ inputs.service }}

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -56,16 +56,18 @@ on:
         required: false
         description: "custom path to access the ECR docker image"
         type: string
+      static-assets-aws-access-key-id:
+        required: true
+        type: string
+      static-assets-aws-secret-access-key:
+        required: true
+        type: string
     secrets:
       PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
         required: false
       JFROG_FLOWCODE_FC_PYPI_USERNAME:
         required: false
       JFROG_FLOWCODE_FC_PYPI_PASSWORD:
-        required: false
-      STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID:
-        required: false
-      STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY:
         required: false
       ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER:
         required: false
@@ -153,8 +155,8 @@ jobs:
           image-tag: ${{ github.sha }}
           ecr-image-path: ${{ inputs.ecr-image-path }}
           post-build-script-inputs: ${{ inputs.post-build-script-inputs }}
-          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID }}
-          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY }}
+          STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ inputs.static-assets-aws-access-key-id }}
+          STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ inputs.static-assets-aws-secret-access-key }}
           ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_SDLC_FC_DOCKER_SERVER }}
       - name: Update fc-infra-kubernetes
         uses: dtx-company/shared-github-workflows/composite-actions/update-infra-kubernetes@v1


### PR DESCRIPTION
## Summary

We need to remove secrets (like [these](https://github.com/dtx-company/flow/blob/a9ae2dd6f89b285296c11c3280e27b558f915c1c/apps/app/env/.env.production)) from the git repository as its a huge security hole and bad practice.

Because these secrets have been in the git history for so long, we won't clean that from the history but can create and use new secrets after they have been functionally removed from the repo.

Steps:

1. Add environment-level secrets to the GitHub project
2. Update flow and shared-github-workflows repositories to use GH environment secrets
3. Remove secrets from the flow repo.


[Shortcut ticket](https://app.shortcut.com/flowcode/story/89814/remove-secrets-from-flow-git-repo)