### PR TITLE
feat: Upload sourcemaps to DataDog

### DIFF
--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -118,7 +118,7 @@ jobs:
           GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
       - name: Extract flow-app assets
         if: inputs.post-build-script != ''
-        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@feat/datadog-sourcemaps
+        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
         with:
           service: ${{ inputs.service }}
           image-tag: ${{ github.sha }}

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -81,7 +81,7 @@ on:
       BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY:
         required: false
       DATADOG_API_KEY:
-        required: true
+        required: false
 
 permissions:
   id-token: write # Required for aws role assumption

--- a/.github/workflows/build-and-push-and-deploy-flow.yaml
+++ b/.github/workflows/build-and-push-and-deploy-flow.yaml
@@ -51,6 +51,10 @@ on:
         required: false
         description: "custom path to access the ECR docker image"
         type: string
+      upload-sourcemaps:
+        required: false
+        description: "upload sourcemap files to DataDog"
+        type: string
     secrets:
       PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD:
         required: true
@@ -76,6 +80,8 @@ on:
         required: false
       BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY:
         required: false
+      DATADOG_API_KEY:
+        required: true
 
 permissions:
   id-token: write # Required for aws role assumption
@@ -112,7 +118,7 @@ jobs:
           GHA_ACTIONS_S3_CACHE_AWS_SECRET_ACCESS_KEY: ${{ secrets.BUILD_ARTIFACTS_S3_CACHE_AWS_SECRET_ACCESS_KEY }}
       - name: Extract flow-app assets
         if: inputs.post-build-script != ''
-        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@v1
+        uses: dtx-company/shared-github-workflows/composite-actions/extract-and-upload-static-assets-flow@feat/datadog-sourcemaps
         with:
           service: ${{ inputs.service }}
           image-tag: ${{ github.sha }}
@@ -121,6 +127,8 @@ jobs:
           STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID: ${{ secrets.STATIC_ASSETS_S3_AWS_ACCESS_KEY_ID }}
           STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY }}
           ECR_FLOWCODE_FC_DOCKER_SERVER: ${{ secrets.ECR_FLOWCODE_FC_DOCKER_SERVER }}
+          upload-sourcemaps: ${{ inputs.upload-sourcemaps }}
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       - name: Update fc-infra-kubernetes
         uses: dtx-company/shared-github-workflows/composite-actions/update-infra-kubernetes@v1
         with:

--- a/composite-actions/extract-and-upload-static-assets-flow/action.yaml
+++ b/composite-actions/extract-and-upload-static-assets-flow/action.yaml
@@ -24,6 +24,13 @@ inputs:
   ECR_FLOWCODE_FC_DOCKER_SERVER:
     required: true
     type: string
+  upload-sourcemaps:
+    required: false
+    description: "upload sourcemap files to DataDog"
+    type: string
+  DATADOG_API_KEY:
+    required: false
+    type: string
 
 runs:
   using: "composite"
@@ -34,6 +41,11 @@ runs:
         echo "AWS_ACCESS_KEY_ID=" >> $GITHUB_ENV
         echo "AWS_SECRET_ACCESS_KEY=" >> $GITHUB_ENV
         echo "AWS_SESSION_TOKEN=" >> $GITHUB_ENV
+    - name: Setup Node.js
+      if: inputs.upload-sourcemaps == 'true'
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
     - uses: shrink/actions-docker-extract@v2
       id: assetExtract
       with:
@@ -61,3 +73,11 @@ runs:
         aws_secret_access_key: ${{ inputs.STATIC_ASSETS_S3_AWS_SECRET_ACCESS_KEY }}
         aws_region: us-east-1
         aws_session_token: ""
+    - name: Upload sourcemaps to DataDog
+      if: inputs.upload-sourcemaps == 'true'
+      shell: bash
+      run: |
+        DATADOG_API_KEY='${{ inputs.DATADOG_API_KEY }}' npx @datadog/datadog-ci sourcemaps upload ./${{ steps.assetExtract.outputs.destination }} \
+        --service=${{ inputs.service }} \
+        --release-version=${{ inputs.image-tag }} \
+        --minified-path-prefix=https://app.flowcode.com/_next/static


### PR DESCRIPTION
Allow flow-app builds to optionally upload the sourcemap files to DataDog.