### PR TITLE
Update checkout action to major version 4

### DIFF
--- a/.github/workflows/bump-build-and-push-cp-pkg.yaml
+++ b/.github/workflows/bump-build-and-push-cp-pkg.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 'lts/*'
+          node-version: "lts/*"
       - name: create-release
         id: release
         run: |
@@ -56,13 +56,13 @@ jobs:
         with:
           command: push configuration -f package.xpkg ${{ steps.login-ecr.outputs.registry }}/${{ inputs.package_name }}:${{ steps.release.outputs.release_tag }}
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Update manifest
         run: |
           sed -i -e "s|${{ steps.login-ecr.outputs.registry }}/${{ inputs.package_name }}:.*|${{ steps.login-ecr.outputs.registry }}/${{ inputs.package_name }}:${{ steps.release.outputs.release_tag }}|g" ./configuration/configuration.yaml
       - name: Commit changes
         uses: EndBug/add-and-commit@v7
         with:
-          add: '.'
+          add: "."
           message: "github bot package version update"
           signoff: true

--- a/.github/workflows/get-image-tag.yaml
+++ b/.github/workflows/get-image-tag.yaml
@@ -48,14 +48,12 @@ jobs:
     outputs:
       imageTag: ${{ steps.step2.outputs.imageTag }}
     steps:
-      -
-        id: step1
-        uses: actions/checkout@v2
+      - id: step1
+        uses: actions/checkout@v4
         with:
           repository: dtx-company/${{ inputs.repository }}
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
-      -
-        id: step2
+      - id: step2
         run: |
           echo "Installing yq..."
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,7 +12,7 @@ jobs:
     # runs-on: self-hosted
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v2
       - uses: ruby/setup-ruby@v1
         with:

--- a/composite-actions/docker-build-and-push-flow-legacy/action.yaml
+++ b/composite-actions/docker-build-and-push-flow-legacy/action.yaml
@@ -137,7 +137,7 @@ runs:
     -
       name: Checkout repo to run post-build script
       if: inputs.post-build-script != ''
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         token: ${{ inputs.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}
     -
@@ -158,7 +158,7 @@ runs:
         ./${{ inputs.post-build-script }}
     -
       name: Checkout kubernetes infra repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: dtx-company/fc-infra-kubernetes
         token: ${{ inputs.PERSONAL_ACCESS_TOKEN_GITHUB_WORKFLOWS_CICD }}


### PR DESCRIPTION
Missed a few in the last PR because I had been searching on `checkout@v3` and not `uses: actions/checkout`. Didn't realize we had some on an even older version!