### PR TITLE
chore: Add cluster name as argument for get-image-tag action

### DIFF
--- a/.github/workflows/get-image-tag.yaml
+++ b/.github/workflows/get-image-tag.yaml
@@ -20,6 +20,11 @@ on:
         type: string
         default: "use1"
         description: "The short aws region name. Ex: use1"
+      cluster:
+        required: false
+        type: string
+        default: "primary"
+        description: "The cluster name. Ex: primary"
       service:
         required: true
         type: string
@@ -61,7 +66,7 @@ jobs:
 
           echo;
           echo "Getting image tag value..."
-          filename="cloud/aws/${{ inputs.account}}/${{ inputs.region}}/primary/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
+          filename="cloud/aws/${{ inputs.account}}/${{ inputs.region}}/${{ inputs.cluster }}/${{ inputs.project }}/applications/${{ inputs.service }}/values.yaml"
           imageTag=$(yq e '.fc-service.process.tag' ${filename})
           echo imageTag value: $imageTag
           echo "::set-output name=imageTag::${imageTag}"


### PR DESCRIPTION
The clusters changed but this action was hardcoded to use the `primary` cluster when my workflow needs to access a different one. This keeps `primary` as the default but allows callers to use a different cluster.